### PR TITLE
ToolManager + QAction/QActionGroups

### DIFF
--- a/WallsAndHoles/toolmanager.cpp
+++ b/WallsAndHoles/toolmanager.cpp
@@ -2,35 +2,86 @@
 #include "toolmanager.h"
 
 ToolManager::ToolManager() {
-
+    mActionGroup = new QActionGroup(this);
 }
 
 
 QAction *ToolManager::registerTool(AbstractToolP tool, QString name) {
-    mTools.insert(name, tool);
 
-    QAction *action = new QAction("Activate tool: " + name);
-    connect(action, &QAction::triggered, this, [this, name]{ activateTool(name); });
+    // This automatically adds action to mActionGroup.
+    QAction *action = new QAction("Activate tool: " + name, mActionGroup);
+    action->setCheckable(true);
+
+
+    connect(action, &QAction::toggled, this, [this, name] (bool checked) {
+        if (checked)
+            activateTool(name);
+        else
+            deactivateTool(name);
+    });
+
+
+    mTools.insert(name, tool);
+    mToolActions.insert(name, action);
 
     return action;
 }
 
+QAction *ToolManager::getAction(QString name) {
+    if (!mToolActions.contains(name))
+        return nullptr;
+    else
+        return mToolActions[name];
+}
+
 void ToolManager::activateTool(QString name) {
 
-    // Deactivate any active tool.
-    if (mActiveTool != nullptr) {
-        mActiveTool->deactivate();
-        mActiveTool = nullptr;
+    // Do nothing if the tool is already active.
+    if (!(mTools.contains(name) && mTools[name] == mActiveTool)) {
+
+        // Deactivate any active tool.
+        if (mActiveTool != nullptr) {
+            mActiveTool->deactivate();
+            mActiveTool = nullptr;
+
+            // This will invoke deactivateTool() for the corresponding tool, but deactivateTool() will not do anything.
+            mActiveAction->setChecked(false);
+            mActiveAction = nullptr;
+        }
+
+        // Activate a tool if a name matches.
+        if (mTools.contains(name)) {
+
+            // Activate the tool.
+            mActiveTool = mTools[name];
+            mActiveTool->activate();
+
+
+            // Check the corresponding action. This will invoke activateTool() which will not do anything
+            // since the tool is already active.
+            mActiveAction = mToolActions[name];
+            if (!action->isChecked())
+                action->setChecked(true);
+
+            emit toolWasActivated(tool, name);
+        }
     }
+}
 
-    // Activate a tool if a name matches.
+void ToolManager::deactivateTool(QString name) {
     if (mTools.contains(name)) {
-        AbstractToolP tool = mTools[name];
+        if (mActiveTool == mTools[name]) {
+            // Deactivate the tool.
+            mActiveTool->deactivate();
+            mActiveTool = nullptr;
 
-        mActiveTool = tool;
-        mActiveTool->activate();
+            // Uncheck the action. NOTE: This will cause another deactivateTool() call with the same name,
+            // but this is not a problem since the tool will not be active.
+            if (mActiveAction->isChecked())
+                mActiveAction->setChecked(false);
 
-        emit toolWasActivated(tool, name);
+            mActiveAction = nullptr;
+        }
     }
 }
 

--- a/WallsAndHoles/toolmanager.cpp
+++ b/WallsAndHoles/toolmanager.cpp
@@ -60,10 +60,10 @@ void ToolManager::activateTool(QString name) {
             // Check the corresponding action. This will invoke activateTool() which will not do anything
             // since the tool is already active.
             mActiveAction = mToolActions[name];
-            if (!action->isChecked())
-                action->setChecked(true);
+            if (!mActiveAction->isChecked())
+                mActiveAction->setChecked(true);
 
-            emit toolWasActivated(tool, name);
+            emit toolWasActivated(mActiveTool, name);
         }
     }
 }

--- a/WallsAndHoles/toolmanager.h
+++ b/WallsAndHoles/toolmanager.h
@@ -37,10 +37,16 @@ public:
      * @brief Registers the tool with the given identifier.
      * @param tool The tool to be registered.
      * @param name The identifier to be given to the tool.
-     * @return A QAction that, when triggered, will call activateTool(name).
+     * @return A QAction that, when toggled, will call either activateTool(name) or deactivateTool(name).
      */
     QAction *registerTool(AbstractToolP tool, QString name);
 
+    /**
+     * @brief Finds the action associated with the name.
+     * @param name The tool name.
+     * @return The action associated, or nullptr if name does not match anything.
+     */
+    QAction *getAction(QString name);
 
 public slots:
     /**
@@ -50,6 +56,14 @@ public slots:
      * This slot can be activated directly from a UI element to enable a tool.
      */
     void activateTool(QString name);
+
+    /**
+     * @brief Deactivates the tool if it is active. NOTE: A ToolManager is exclusive,
+     * so activateTool() automatically deactivates the previous tool.
+     *
+     * @param name The name of the tool.
+     */
+    void deactivateTool(QString name);
 
 
     void mousePressEvent(QMouseEvent *event);
@@ -67,9 +81,13 @@ signals:
     void toolWasActivated(AbstractToolP tool, QString name);
 
 protected:
-    QMap<QString, AbstractToolP> mTools;
+    QMap<QString, AbstractToolP> mTools;  /// A map from tool names to tool objects.
+    QMap<QString, QAction*> mToolActions; /// The actions associated to each tool. All pointers delete selves when the ToolManager is destructed.
 
-    AbstractToolP mActiveTool;
+    QActionGroup *mActionGroup; /// The action group containing all of the ToolManager's actions.
+
+    AbstractToolP mActiveTool; /// The active tool.
+    QAction *mActiveAction;    /// The QAction of the active tool.
 };
 
 typedef QSharedPointer<ToolManager> ToolManagerP;


### PR DESCRIPTION
The QActionGroup is exclusive.

The QAction returned by registerTool() is checkable, and its toggled()
signal invokes either activateTool() or deactivateTool() appropriately.

Calling activateTool() or deactivateTool() manually WILL check /
uncheck the related actions appropriately.