### PR TITLE
Docking bugfix

### DIFF
--- a/WallsAndHoles/abstractdrawableglobject.h
+++ b/WallsAndHoles/abstractdrawableglobject.h
@@ -15,6 +15,12 @@ public:
     virtual ~AbstractDrawableGLObject() {}
     
     /**
+     * @brief Called when this object is to be used with a new OpenGL context.
+     * Must be called before the first draw() call in the context.
+     */
+    virtual void initializeGL() = 0;
+
+    /**
      * @brief Performs OpenGL calls to draw the object, assuming a context is bound.
      * @param projection        The projection matrix used for the meshes.
      * @param transformation    The transformation matrix used for the meshes. The

--- a/WallsAndHoles/drawableaxes.cpp
+++ b/WallsAndHoles/drawableaxes.cpp
@@ -4,23 +4,16 @@
 #include "drawableaxes.h"
 
 DrawableAxes::DrawableAxes()
-    : initialized(false)
 {
 
 }
 
-DrawableAxes::~DrawableAxes() {
-    delete mVAO;
-    delete mPos;
-    delete mColor;
-}
-
-void DrawableAxes::initialize() {
+void DrawableAxes::initializeGL() {
     initializeOpenGLFunctions();
 
-    mProgram = QSharedPointer<QOpenGLShaderProgram>::create();
-    mProgram->addShaderFromSourceFile(QOpenGLShader::Vertex, ":/shaders/colors.vsh");
-    mProgram->addShaderFromSourceFile(QOpenGLShader::Fragment, ":/shaders/colors.fsh");
+    mProgram = QSharedPointer<QOpenGLShaderProgram>::create(nullptr);
+    mProgram->addCacheableShaderFromSourceFile(QOpenGLShader::Vertex, ":/shaders/colors.vsh");
+    mProgram->addCacheableShaderFromSourceFile(QOpenGLShader::Fragment, ":/shaders/colors.fsh");
     mProgram->link();
 
     float length = 10;
@@ -39,21 +32,21 @@ void DrawableAxes::initialize() {
                    0, 0, 1, 1,
                    0, 0, 1, 1};
 
-    mPos = new QOpenGLBuffer(QOpenGLBuffer::VertexBuffer);
+    mPos = QSharedPointer<QOpenGLBuffer>::create(QOpenGLBuffer::VertexBuffer);
     mPos->create();
     mPos->bind();
     mPos->setUsagePattern(QOpenGLBuffer::StaticDraw);
     mPos->allocate(pos, 3 * 6 * sizeof(float));
     mPos->release();
 
-    mColor = new QOpenGLBuffer(QOpenGLBuffer::VertexBuffer);
+    mColor = QSharedPointer<QOpenGLBuffer>::create(QOpenGLBuffer::VertexBuffer);
     mColor->create();
     mColor->bind();
     mColor->setUsagePattern(QOpenGLBuffer::StaticDraw);
     mColor->allocate(col, 4 * 6 * sizeof(float));
     mColor->release();
 
-    mVAO = new QOpenGLVertexArrayObject();
+    mVAO = QSharedPointer<QOpenGLVertexArrayObject>::create(nullptr);
     mVAO->create();
     mVAO->bind();
 
@@ -69,18 +62,10 @@ void DrawableAxes::initialize() {
 
     mVAO->release();
 
-
-    initialized = true;
 }
 
 
 void DrawableAxes::draw(QMatrix4x4 projection, QMatrix4x4 transformation) {
-
-    // Initialize on the first call. This sets up shaders and buffers.
-    if (!initialized)
-        initialize();
-
-
     mProgram->bind();
     mProgram->setUniformValue("mvp", projection * transformation);
 

--- a/WallsAndHoles/drawableaxes.h
+++ b/WallsAndHoles/drawableaxes.h
@@ -17,26 +17,17 @@
 class DrawableAxes : public AbstractDrawableGLObject, public QOpenGLFunctions {
 public:
     DrawableAxes();
-    ~DrawableAxes();
 
+    void initializeGL() override;
     void draw(QMatrix4x4 projection, QMatrix4x4 transformation) override;
 
 protected:
 
-    QOpenGLVertexArrayObject *mVAO;
-    QOpenGLBuffer *mPos;
-    QOpenGLBuffer *mColor;
+    QSharedPointer<QOpenGLVertexArrayObject> mVAO;
+    QSharedPointer<QOpenGLBuffer> mPos;
+    QSharedPointer<QOpenGLBuffer> mColor;
 
     QSharedPointer<QOpenGLShaderProgram> mProgram;
-
-
-    // Whether initialize() has been called yet.
-    bool initialized;
-
-    /**
-     * @brief Called during first draw() call to initialize buffers and shaders.
-     */
-    void initialize();
 };
 
 #endif // DRAWABLEAXES_H

--- a/WallsAndHoles/meshview.h
+++ b/WallsAndHoles/meshview.h
@@ -54,12 +54,12 @@ protected:
 
 
     // Shader program.
-    QOpenGLShaderProgram mBasicProgram;
+    QSharedPointer<QOpenGLShaderProgram> mBasicProgram;
 
     // VAO and buffers for rendering.
-    QOpenGLVertexArrayObject mVAO;
-    QOpenGLBuffer mVertexPositions;
-    QOpenGLBuffer mTriangleIndices;
+    QSharedPointer<QOpenGLVertexArrayObject> mVAO;
+    QSharedPointer<QOpenGLBuffer> mVertexPositions;
+    QSharedPointer<QOpenGLBuffer> mTriangleIndices;
 
     // Scene object that is rendered.
     QSharedPointer<Scene> mScene;

--- a/WallsAndHoles/scene.cpp
+++ b/WallsAndHoles/scene.cpp
@@ -22,6 +22,7 @@ const QVector<Scene::DrawableObjectP>& Scene::getAllDrawables() const {
     return drawables;
 }
 
+
 size_t Scene::getNumVertices() const {
     size_t total = 0;
 
@@ -29,4 +30,10 @@ size_t Scene::getNumVertices() const {
         total += obj->getNumVertices();
 
     return total;
+}
+
+
+void Scene::initializeGL() {
+    for (DrawableObjectP drawable : drawables)
+        drawable->initializeGL();
 }

--- a/WallsAndHoles/scene.h
+++ b/WallsAndHoles/scene.h
@@ -31,6 +31,12 @@ public:
     size_t getNumVertices() const;
 
 
+    /**
+     * @brief Calls initialzeGL() on all drawables.
+     */
+    void initializeGL();
+
+
     const QVector<DrawableObjectP>& getAllDrawables() const;
     const QVector<RenderableObjectP>& getAllObjects() const;
 


### PR DESCRIPTION
Fixed the crash when undocking/docking the mesh view. It happened because a new GL context was created, and the code did not handle it properly.