### PR TITLE
Lots of changes to the Tile Pipeline

### DIFF
--- a/WallsAndHoles/WallsAndHoles.pro
+++ b/WallsAndHoles/WallsAndHoles.pro
@@ -67,7 +67,8 @@ HEADERS += \
     rectcell.h \
     mapview.h \
     editor.h \
-    newmapdialog.h
+    newmapdialog.h \
+    array2d.h
 
 FORMS += \
     mainwindow.ui \

--- a/WallsAndHoles/array2d.h
+++ b/WallsAndHoles/array2d.h
@@ -2,7 +2,7 @@
 #define ARRAY2D_H
 
 #include <QVector>
-
+#include <QSize>
 
 /**
  * @brief The Array2D class is basically a 2D implementation of QVector.
@@ -28,6 +28,16 @@ public:
     Type& operator()(int r, int c) {
         return data[r][c];
     }
+
+    void resize(int rows, int cols)
+    {
+        data.resize(rows);
+        for (QVector<Type> v : data)
+            v.resize(cols);
+    }
+
+    QSize size() const { return QSize(data.size(),
+                                      data.empty()? 0 : data[0].size()); }
 
 protected:
     QVector<QVector<Type>> data;

--- a/WallsAndHoles/array2d.h
+++ b/WallsAndHoles/array2d.h
@@ -1,0 +1,36 @@
+#ifndef ARRAY2D_H
+#define ARRAY2D_H
+
+#include <QVector>
+
+
+/**
+ * @brief The Array2D class is basically a 2D implementation of QVector.
+ *
+ * Usage:
+ *  // Construction.
+ *  arr = Array2D<YourType>(rows, cols).
+ *
+ *  // Access.
+ *  arr(r,c) = obj;
+ */
+template< typename Type >
+class Array2D {
+public:
+    Array2D(int rows, int cols) {
+        data = QVector<QVector<Type>>(rows, QVector<Type>(cols));
+    }
+
+    const Type& operator()(int r, int c) const {
+        return data[r][c];
+    }
+
+    Type& operator()(int r, int c) {
+        return data[r][c];
+    }
+
+protected:
+    QVector<QVector<Type>> data;
+};
+
+#endif // ARRAY2D_H

--- a/WallsAndHoles/mainwindow.cpp
+++ b/WallsAndHoles/mainwindow.cpp
@@ -8,8 +8,7 @@
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
-    ui(new Ui::MainWindow),
-    mMeshViewContainer(nullptr)
+    ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
 }
@@ -17,21 +16,4 @@ MainWindow::MainWindow(QWidget *parent) :
 MainWindow::~MainWindow()
 {
     delete ui;
-    delete mMeshViewContainer;
 }
-
-
-void MainWindow::openMeshView() {
-    if (mMeshViewContainer == nullptr) {
-        mMeshViewContainer = new MeshViewContainer();
-        mMeshViewContainer->show();
-    }
-}
-
-void MainWindow::on_pushButton_clicked() {
-    openMeshView();
-}
-
-
-
-

--- a/WallsAndHoles/mainwindow.h
+++ b/WallsAndHoles/mainwindow.h
@@ -18,16 +18,8 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
-public slots:
-    void openMeshView();
-
-private slots:
-    void on_pushButton_clicked();
-
 private:
     Ui::MainWindow *ui;
-
-    MeshViewContainer *mMeshViewContainer;
 };
 
 #endif // MAINWINDOW_H

--- a/WallsAndHoles/mainwindow.ui
+++ b/WallsAndHoles/mainwindow.ui
@@ -6,34 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
-    <height>395</height>
+    <width>1045</width>
+    <height>694</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="QWidget" name="centralWidget">
-   <widget class="QPushButton" name="pushButton">
-    <property name="geometry">
-     <rect>
-      <x>190</x>
-      <y>190</y>
-      <width>113</width>
-      <height>32</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Show View</string>
-    </property>
-   </widget>
-  </widget>
+  <widget class="QWidget" name="centralWidget"/>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>493</width>
+     <width>1045</width>
      <height>21</height>
     </rect>
    </property>

--- a/WallsAndHoles/tile.h
+++ b/WallsAndHoles/tile.h
@@ -14,12 +14,14 @@ class Tile : public QObject
     Q_OBJECT
 
 public:
-    explicit Tile(const SharedTileTemplate tileTemplate,
+    explicit Tile(SharedTileTemplate tileTemplate,
                   int xPos = -1,
                   int yPos = -1,
                   QObject *parent = nullptr);
 
-    const SharedTileTemplate tileTemplate() const { return mTileTemplate; }
+    ~Tile();
+
+    SharedTileTemplate tileTemplate() const { return mTileTemplate; }
 
     float relativeThickness() const { return mRelativeThickness; }
     float relativeHeight() const { return mRelativeHeight; }
@@ -32,11 +34,25 @@ public:
     //will be clipped so that walls don't leave tilebounds
     void setRelativePosition(QVector2D relavtivePosition);
 
+    /**
+     * Sets all relative values to zero,
+     * and changes the tileTemplate to newTileTemplate
+     */
+    void resetTile(SharedTileTemplate newTileTemplate);
+
+    bool isEmpty() const { return mTileTemplate.isNull(); }
+
 signals:
     void tileChanged(int x, int y);
 
+public slots:
+    //by calling the respective set functions, it is ensured that the tile wont go out of bounds.
+    //the signal tileChanged is also emited as expected
+    void templateThicknessChanged() { setRelativePosition(mRelativePosition); }
+    void templatePositionChanged() { setRelativeThickness(mRelativeThickness); }
+
 private:
-    const SharedTileTemplate mTileTemplate;
+    SharedTileTemplate mTileTemplate;
 
     const int mXPos;
     const int mYPos;
@@ -51,10 +67,10 @@ private:
     //As with above, this is added to the base tileHeights height
     float mRelativeHeight;
 
-    //let x = (1 - mSize) / 2;
-    //then both x and y are between -x and x (inclusive)
+    //let w = (1 - mSize) / 2;
+    //then both x and y are between -w and w (inclusive)
     //This is the offset of the tile relative to the center of it's grid position
-    //(0,0 would be the centered regardless of the tiles coordinates)
+    //(0.5,0.5 would be the centered regardless of the tiles coordinates)
     QVector2D mRelativePosition;
 
     //other properties to come as we develop further

--- a/WallsAndHoles/tile.h
+++ b/WallsAndHoles/tile.h
@@ -14,7 +14,7 @@ class Tile : public QObject
     Q_OBJECT
 
 public:
-    explicit Tile(SharedTileTemplate tileTemplate,
+    explicit Tile(SharedTileTemplate tileTemplate = nullptr,
                   int xPos = -1,
                   int yPos = -1,
                   QObject *parent = nullptr);

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -1,6 +1,7 @@
 #ifndef TILEMAP_H
 #define TILEMAP_H
 
+#include "array2d.h"
 #include "tile.h"
 #include "tiletemplate.h"
 
@@ -16,8 +17,6 @@ public:
     TileMap(QSize mapSize,
             QObject *parent = nullptr);
 
-    ~TileMap();
-
     Tile &tileAt(int x, int y);
     const Tile &cTileAt(int x, int y) const;
 
@@ -29,7 +28,7 @@ public:
     //sets the whole map to the default
     void clear();
 
-    QSize mapSize() const { return mMapSize; }
+    QSize mapSize() const { return mMap.size(); }
 
     //changes the size of the map. If the size is reduced, tiles will be lost (resizes around top left corner)
     void resizeMap(QSize newSize);
@@ -40,9 +39,7 @@ signals:
 
 private:
     //2D array of Tile*. If mMap[x][y]->isEmpty() then ground is shown
-    Tile ***mMap;
-
-    QSize mMapSize;
+    Array2D<QSharedPointer<Tile>> mMap;
 };
 
 typedef QSharedPointer<TileMap> SharedTileMap;

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -14,7 +14,6 @@ class TileMap : public QObject
 
 public:
     TileMap(QSize mapSize,
-            const SharedTileTemplate defaultTileTemplate,
             QObject *parent = nullptr);
 
     ~TileMap();
@@ -22,10 +21,10 @@ public:
     Tile &tileAt(int x, int y);
     const Tile &cTileAt(int x, int y) const;
 
-    void setTile(int x, int y, QSharedPointer<Tile> tile);
+    void setTile(int x, int y, SharedTileTemplate tileTemplate);
 
     //sets this tile to the default
-    void clearTile(int x, int y);
+    void clearTile(int x, int y) { setTile(x, y, nullptr); }
 
     //sets the whole map to the default
     void clear();
@@ -37,14 +36,13 @@ public:
 
 signals:
     void tileChanged(int x, int y);
-    void sizeChanged();
+    void resized();
 
 private:
-    QSharedPointer<Tile> **mMap;
+    //2D array of Tile*. If mMap[x][y]->isEmpty() then ground is shown
+    Tile ***mMap;
 
     QSize mMapSize;
-
-    const SharedTileTemplate mDefaultTileTemplate;
 };
 
 typedef QSharedPointer<TileMap> SharedTileMap;

--- a/WallsAndHoles/tiletemplate.cpp
+++ b/WallsAndHoles/tiletemplate.cpp
@@ -2,19 +2,19 @@
 
 TileTemplate::TileTemplate(float height,
                            float thickness,
-                           QVector2D position,
+                           QVector2D position, QColor color,
                            QObject *parent)
     : QObject(parent)
-    , mTileId(-1)
     , mHeight(height)
     , mThickness(thickness)
-    , mPosition(position) {}
+    , mPosition(position)
+    , mColor(color) {}
 
 void TileTemplate::setHeight(float height)
 {
     mHeight = height;
 
-    emit propertyChanged(mTileId);
+    emit exclusivePropertyChanged();
 }
 
 void TileTemplate::setThickness(float thickness)
@@ -23,7 +23,7 @@ void TileTemplate::setThickness(float thickness)
 
     mThickness = thickness;
 
-    emit propertyChanged(mTileId);
+    emit thicknessChanged();
 }
 
 void TileTemplate::setPosition(QVector2D position)
@@ -35,5 +35,12 @@ void TileTemplate::setPosition(QVector2D position)
 
     mPosition = position;
 
-    emit propertyChanged(mTileId);
+    emit positionChanged();
+}
+
+void TileTemplate::setColor(QColor color)
+{
+    mColor = color;
+
+    emit exclusivePropertyChanged();
 }

--- a/WallsAndHoles/tiletemplate.h
+++ b/WallsAndHoles/tiletemplate.h
@@ -6,6 +6,7 @@
 #include <QSharedPointer>
 #include <QObject>
 #include <QVector2D>
+#include <QColor>
 
 class TileTemplate : public QObject
 {
@@ -15,26 +16,38 @@ public:
     explicit TileTemplate(float height = 0,
                           float thickness = 0,
                           QVector2D position = QVector2D(0.5, 0.5),
+                          QColor color = Qt::white,
                           QObject *parent = nullptr);
 
-    void setTileId(int id) { mTileId = id; }
     void setHeight(float height);
+
+    // TODO: these should ensure the resulting tile stays inbounds
     void setThickness(float thickness);
     void setPosition(QVector2D position);
 
-    int tileId() const { return mTileId; }
+    void setColor(QColor color);
+
     float height() const { return mHeight; }
     float thickness() const { return mThickness; }
     QVector2D position() const { return mPosition; }
 
+    QColor color() const { return mColor; }
+
 signals:
-    void propertyChanged(int tileId);
+    //a property which has no affect on other properties (ie not thickness or position)
+    //but rendering should be updated
+    void exclusivePropertyChanged();
+    void thicknessChanged();
+    void positionChanged();
 
 private:
-    int mTileId;
     float mHeight;
     float mThickness;
     QVector2D mPosition;
+
+    //The color the tile will be in the map view.
+    //Has no affect on evental output mesh
+    QColor mColor;
 };
 
 typedef QSharedPointer<TileTemplate> SharedTileTemplate;

--- a/WallsAndHoles/tiletemplateset.cpp
+++ b/WallsAndHoles/tiletemplateset.cpp
@@ -3,12 +3,9 @@
 TileTemplateSet::TileTemplateSet(QObject *parent)
     : QObject(parent) {}
 
-void TileTemplateSet::addTileTemplate(TileTemplate *tileTemplate)
+void TileTemplateSet::addTileTemplate(SharedTileTemplate tileTemplate)
 {
-    tileTemplate->setTileId(mTileTemplates.size());
-    mTileTemplates.append(SharedTileTemplate(tileTemplate));
-    connect(tileTemplate, &TileTemplate::propertyChanged,
-            this, &TileTemplateSet::tileTemplateChanged);
+    mTileTemplates.append(tileTemplate);
 
     emit tileTemplateAdded(mTileTemplates.size() - 1);
 }
@@ -18,11 +15,6 @@ void TileTemplateSet::removeTileTemplate(int index)
     Q_ASSERT(index >= 0 && index < mTileTemplates.size());
 
     mTileTemplates.removeAt(index);
-
-    //updates the tileId of all templates
-    for (auto it = mTileTemplates.begin() + index; it != mTileTemplates.end(); ++it) {
-        (*it)->setTileId(index++);
-    }
 
     emit tileTemplateRemoved(index);
 }

--- a/WallsAndHoles/tiletemplateset.h
+++ b/WallsAndHoles/tiletemplateset.h
@@ -15,7 +15,7 @@ public:
 
     //Adds the given tileTemplate to the end of the tileList
     //should pass new TileTemplate(...) to this
-    void addTileTemplate(TileTemplate *tileTemplate);
+    void addTileTemplate(SharedTileTemplate tileTemplate);
 
     //removes the tiletemplate at the specified index
     void removeTileTemplate(int index);
@@ -29,7 +29,6 @@ public:
 
 signals:
     void tileTemplateAdded(int tileId);
-    void tileTemplateChanged(int tileId);
     void tileTemplateRemoved(int tileId);
 
 public slots:


### PR DESCRIPTION
Mainly: Now TileTemplate emits a signal to tiles when changed,
whenever a Tile changed, it emits a signal to the TileMap,
which forwards it to whoever wants it (mapview/meshview...)
As well, the TileMap's array of tiles now stay the same, and the tiles
are just changed, which previously was not the case.