### PR TITLE
Big speedup to Map2Mesh

### DIFF
--- a/WallsAndHoles/map2mesh.cpp
+++ b/WallsAndHoles/map2mesh.cpp
@@ -2,6 +2,8 @@
 // For std::min_element
 #include <algorithm>
 
+#include <QTimer>
+
 #include "map2mesh.h"
 
 #include "m2mtilemesher.h"
@@ -19,7 +21,8 @@ Map2Mesh::Map2Mesh(TileMap *tileMap, QObject *parent)
 }
 
 
-QVector<QSharedPointer<RenderableObject>> Map2Mesh::getMeshes() const {
+QVector<QSharedPointer<RenderableObject>> Map2Mesh::getMeshes() const
+{
     QVector<QSharedPointer<RenderableObject>> meshes;
 
     for (QSharedPointer<RenderableObject> tileMesh : mTileMeshes)
@@ -29,28 +32,34 @@ QVector<QSharedPointer<RenderableObject>> Map2Mesh::getMeshes() const {
 }
 
 
-void Map2Mesh::tileChanged(int x, int y) {
-    // TODO: Possibly inefficient.
-    inferProperties();
+void Map2Mesh::tileChanged(int x, int y)
+{
+    if (!mInferScheduled) {
+        mInferScheduled = true;
 
-    emit mapMeshUpdated();
+        QTimer::singleShot(500, this, [this] () {
+            mInferScheduled = false;
+            inferProperties();
+        });
+    }
 }
 
 
-void Map2Mesh::remakeAll() {
+void Map2Mesh::remakeAll()
+{
     mTileMeshes = Array2D<QSharedPointer<RenderableObject>>(mTileMap->mapSize());
 
     // Reset tile properties to a 0x0 grid so that all meshes are changed in inferProperties.
     mTileProperties = Array2D<M2MPropertySet>();
 
     inferProperties();
-
-
-    emit mapMeshUpdated();
 }
 
 
-void Map2Mesh::inferProperties() {
+
+// TODO: There may be threading issues here! What if mTileMap changes while we are processing?
+void Map2Mesh::inferProperties()
+{
     const Array2D<QSharedPointer<Tile>> &grid = mTileMap->getArray2D();
 
     Array2D<M2MPropertySet> newProperties = Array2D<M2MPropertySet>(mTileMap->mapSize());
@@ -99,5 +108,8 @@ void Map2Mesh::inferProperties() {
     }
 
     mTileProperties = newProperties;
+
+
+    emit mapMeshUpdated();
 }
 

--- a/WallsAndHoles/map2mesh.h
+++ b/WallsAndHoles/map2mesh.h
@@ -80,6 +80,11 @@ protected:
     Array2D<M2MPropertySet> mTileProperties;
 
 
+    /**
+     * @brief Whether an inferProperties() call has been scheduled. Used in tileChanged().
+     */
+    bool mInferScheduled;
+
 public:
     struct Properties {
         static M2MPropertyClass *Height;


### PR DESCRIPTION
The change is very small: I added a QTimer to Map2Mesh::tileChanged() so that inferProperties() is not called too frequently. This makes everything run much much faster.