### PR TITLE
Vast TileTemplateSet improvments and View

### DIFF
--- a/WallsAndHoles/WallsAndHoles.pro
+++ b/WallsAndHoles/WallsAndHoles.pro
@@ -54,6 +54,9 @@ SOURCES += \
     m2mpropertyinstance.cpp \
     m2mpropertyset.cpp \
     map2meshproperties.cpp \
+    tiletemplatesetsview.cpp \
+    newtiletemplatesetdialog.cpp \
+    tiletemplateeditor.cpp \
     mapcellgraphicsitem.cpp \
     abstractshapebrushtool.cpp \
     linebrushtool.cpp \
@@ -74,7 +77,6 @@ HEADERS += \
     tile.h \
     tilemap.h \
     tiletemplate.h \
-    tiletemplateset.h \
     abstracttool.h \
     abstractmeshviewcamera.h \
     abstractdrawableglobject.h \
@@ -96,6 +98,10 @@ HEADERS += \
     m2mpropertyclass.h \
     m2mpropertyinstance.h \
     m2mpropertyset.h \
+    tiletemplateset.h \
+    tiletemplatesetsview.h \
+    newtiletemplatesetdialog.h \
+    tiletemplateeditor.h \
     mapcellgraphicsitem.h \
     abstractshapebrushtool.h \
     linebrushtool.h \

--- a/WallsAndHoles/abstractshapebrushtool.cpp
+++ b/WallsAndHoles/abstractshapebrushtool.cpp
@@ -1,12 +1,8 @@
 #include "abstractshapebrushtool.h"
 
-AbstractShapeBrushTool::AbstractShapeBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawWith)
+AbstractShapeBrushTool::AbstractShapeBrushTool(MapView *mapView, TileMap *tileMap)
     : AbstractTileMapTool(tileMap),
-      mMapView(mapView),
-      mDrawMaterial(drawWith)
-{
-
-}
+      mMapView(mapView) {}
 
 
 void AbstractShapeBrushTool::cellClicked(int x, int y) {
@@ -20,16 +16,17 @@ void AbstractShapeBrushTool::cellClicked(int x, int y) {
 }
 
 
-void AbstractShapeBrushTool::cellActivated(int x, int y) {
+void AbstractShapeBrushTool::cellActivated(int x, int y)
+{
     drawOverlay(x, y);
 }
 
 
-void AbstractShapeBrushTool::cellReleased(int x, int y) {
+void AbstractShapeBrushTool::cellReleased(int x, int y)
+{
     clearOverlay();
     placeShape(x, y);
 }
-
 
 
 void AbstractShapeBrushTool::drawOverlay(int endX, int endY) {
@@ -63,6 +60,6 @@ void AbstractShapeBrushTool::placeShape(int endX, int endY) {
         int y = mStartY + p.y();
 
         if (x >= 0 && x < mTileMap->width() && y >= 0 && y < mTileMap->height())
-            mTileMap->setTile(x, y, mDrawMaterial);
+            mTileMap->setTile(x, y, mTileTemplate);
     }
 }

--- a/WallsAndHoles/abstractshapebrushtool.h
+++ b/WallsAndHoles/abstractshapebrushtool.h
@@ -11,16 +11,14 @@
 #include "mapview.h"
 #include "mapoverlaycell.h"
 
-class AbstractShapeBrushTool : public AbstractTileMapTool {
+class AbstractShapeBrushTool : public AbstractTileMapTool
+{
 public:
-
-    AbstractShapeBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawWith);
-
+    AbstractShapeBrushTool(MapView *mapView, TileMap *tileMap);
 
     void cellClicked(int x, int y) override;
     void cellActivated(int x, int y) override;
     void cellReleased(int x, int y) override;
-
 
     /**
      * @brief This function should output a QVector of points that should be filled in.
@@ -45,9 +43,6 @@ private:
 
     /// The overlay that is drawn over the map view.
     Array2D<QSharedPointer<MapOverlayCell>> mOverlay;
-
-    /// The tile template that will be placed down on the map.
-    SharedTileTemplate mDrawMaterial;
 
     /// Draws an overlay previewing the shape that will be drawn.
     void drawOverlay(int endX, int endY);

--- a/WallsAndHoles/abstracttilemaptool.h
+++ b/WallsAndHoles/abstracttilemaptool.h
@@ -3,13 +3,18 @@
 
 #include "abstracttool.h"
 #include "tilemap.h"
+#include "tiletemplate.h"
 
 class AbstractTileMapTool : public AbstractTool
 {
 public:
-    AbstractTileMapTool(TileMap *tileMap) : mTileMap(tileMap) {}
+    AbstractTileMapTool(TileMap *tileMap)
+        : mTileMap(tileMap)
+        , mTileTemplate(nullptr) {}
 
     void setTileMap(TileMap *tileMap) { mTileMap = tileMap; }
+
+    void setTileTemplate(SharedTileTemplate tileTemplate) { mTileTemplate = tileTemplate; }
 
     /**
      * @brief Called when the left mouse button is down over a new cell.
@@ -43,6 +48,7 @@ public:
 
 protected:
     TileMap *mTileMap;
+    SharedTileTemplate mTileTemplate;
 
 private:
     using AbstractTool::mousePressEvent;

--- a/WallsAndHoles/editor.cpp
+++ b/WallsAndHoles/editor.cpp
@@ -16,44 +16,49 @@
 #include <QMessageBox>
 #include <QFileDialog>
 
+#include <QListView>
+
 Editor::Editor(QObject *parent)
     : QObject(parent)
     , mMainWindow(new QMainWindow())
     , mMap2Mesh(nullptr)
     , mTileMap(nullptr)
-    , mTileTemplateSet(new TileTemplateSet)
     , mMapView(new MapView(mTileMapSelectedRegion, mMainWindow))
     , mTileMapToolManager(new TileMapToolManager(this))
     , mToolBar(new QToolBar(mMainWindow))
 {
-    //TMP set up a basic tileTemplate
-    mTileTemplateSet->addTileTemplate(SharedTileTemplate(new TileTemplate(2, 1, QVector2D(0.5,0.5), Qt::red)));
-
     //Initiallize mMainWindow
     mMainWindow->setCentralWidget(mMapView);
     setUpMenuBar();
     mMainWindow->addToolBar(mToolBar);
 
     // Add tools.
+
     mToolBar->addAction(mTileMapToolManager->registerMapTool(
-                            QSharedPointer<TileMapBrushTool>::create(mTileMap, mTileTemplateSet->tileTemplates()[0]),
-                        "Brush Tool"));
+                            QSharedPointer<TileMapBrushTool>::create(mTileMap)
+                            , "Brush Tool"));
     mToolBar->addAction(mTileMapToolManager->registerMapTool(
-                            QSharedPointer<LineBrushTool>::create(mMapView, mTileMap, mTileTemplateSet->tileTemplates()[0]),
-                        "Line Tool"));
+                            QSharedPointer<LineBrushTool>::create(mMapView, mTileMap)
+                            , "Line Tool"));
     mToolBar->addAction(mTileMapToolManager->registerMapTool(
-                            QSharedPointer<RectBrushTool>::create(mMapView, mTileMap, mTileTemplateSet->tileTemplates()[0]),
-                        "Rect Tool"));
+                            QSharedPointer<RectBrushTool>::create(mMapView, mTileMap)
+                            , "Rect Tool"));
     mToolBar->addAction(mTileMapToolManager->registerMapTool(
-                            QSharedPointer<EllipseBrushTool>::create(mMapView, mTileMap, mTileTemplateSet->tileTemplates()[0]),
-                        "Ellipse Tool"));
+                            QSharedPointer<EllipseBrushTool>::create(mMapView, mTileMap)
+                            , "Ellipse Tool"));
 
     //Set up and add all dock widgets
     QDockWidget *dw = new QDockWidget("Mesh View", mMainWindow);
     mMeshViewContainer = new MeshViewContainer(dw);
     dw->setWidget(mMeshViewContainer);
 
+    //TMP testing templatesets model view
+    QDockWidget *tdw = new QDockWidget("Template Set View", mMainWindow);
+    mTileTemplateSetsView = new TileTemplateSetsView(tdw);
+    tdw->setWidget(mTileTemplateSetsView);
+
     mMainWindow->addDockWidget(Qt::RightDockWidgetArea, dw);
+    mMainWindow->addDockWidget(Qt::LeftDockWidgetArea, tdw);
 
     //Create widget connections
     connect(mMapView, &MapView::cellActivated,
@@ -62,6 +67,9 @@ Editor::Editor(QObject *parent)
             mTileMapToolManager, &TileMapToolManager::cellClicked);
     connect(mMapView, &MapView::cellReleased,
             mTileMapToolManager, &TileMapToolManager::cellReleased);
+
+    connect(mTileTemplateSetsView, &TileTemplateSetsView::tileTemplateChanged,
+            mTileMapToolManager, &TileMapToolManager::tileTemplateChanged);
 
     mMainWindow->showMaximized();
 }
@@ -118,7 +126,7 @@ void Editor::saveMap()
         messageBox.setFixedSize(500,200);
         return;
     }
-    mTileMap->setDepend(QSharedPointer<TileTemplateSet>(mTileTemplateSet));
+    //mTileMap->setDepend(QSharedPointer<TileTemplateSet>(mTileTemplateSets[0]));
     //mTileMap->updateDepend();
     if(mTileMap->savePath().isEmpty()){
         mTileMap->setSavePath(QFileDialog::getSaveFileName(mMainWindow,
@@ -147,7 +155,7 @@ void Editor::loadMap()
     }
     mTileMap = tileMap.data();
     if(!mTileMap->dependencies().isEmpty())
-        mTileTemplateSet = (mTileMap->dependencies()[0]).data();
+        //mTileTemplateSets[0] = (mTileMap->dependencies()[0]);
     mTileMapToolManager->setTileMap(mTileMap);
     mMapView->createMap(mTileMap);
 }

--- a/WallsAndHoles/editor.h
+++ b/WallsAndHoles/editor.h
@@ -8,8 +8,10 @@
 #include "xmltool.h"
 #include "map2mesh.h"
 #include "meshviewcontainer.h"
+#include "tiletemplatesetsview.h"
 
 #include <QObject>
+#include <QList>
 #include <QToolBar>
 
 /**
@@ -50,12 +52,10 @@ private:
     TileMap *mTileMap;
     QRegion mTileMapSelectedRegion;
 
-    //TileTemplateSet data
-    TileTemplateSet *mTileTemplateSet;
-
     //views
     MapView *mMapView;
     MeshViewContainer *mMeshViewContainer;
+    TileTemplateSetsView *mTileTemplateSetsView;
 
     //Tools
     TileMapToolManager *mTileMapToolManager;

--- a/WallsAndHoles/ellipsebrushtool.cpp
+++ b/WallsAndHoles/ellipsebrushtool.cpp
@@ -4,8 +4,8 @@
 #include "ellipsebrushtool.h"
 
 
-EllipseBrushTool::EllipseBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawWith)
-    : AbstractShapeBrushTool(mapView, tileMap, drawWith)
+EllipseBrushTool::EllipseBrushTool(MapView *mapView, TileMap *tileMap)
+    : AbstractShapeBrushTool(mapView, tileMap)
 {
 
 }

--- a/WallsAndHoles/ellipsebrushtool.h
+++ b/WallsAndHoles/ellipsebrushtool.h
@@ -5,7 +5,7 @@
 
 class EllipseBrushTool : public AbstractShapeBrushTool {
 public:
-    EllipseBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawMaterial);
+    EllipseBrushTool(MapView *mapView, TileMap *tileMap);
 
     /// Draws an ellipse.
     QVector<QPoint> getShape(int dx, int dy) const override;

--- a/WallsAndHoles/linebrushtool.cpp
+++ b/WallsAndHoles/linebrushtool.cpp
@@ -5,13 +5,11 @@
 
 #include "linebrushtool.h"
 
-LineBrushTool::LineBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawMaterial)
-    : AbstractShapeBrushTool(mapView, tileMap, drawMaterial)
+LineBrushTool::LineBrushTool(MapView *mapView, TileMap *tileMap)
+    : AbstractShapeBrushTool(mapView, tileMap)
 {
 
 }
-
-
 
 QVector<QPoint> LineBrushTool::getShape(int dx, int dy) const {
 

--- a/WallsAndHoles/linebrushtool.h
+++ b/WallsAndHoles/linebrushtool.h
@@ -6,7 +6,7 @@
 
 class LineBrushTool : public AbstractShapeBrushTool {
 public:
-    LineBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawMaterial);
+    LineBrushTool(MapView *mapView, TileMap *tileMap);
 
     /**
      * @brief Makes a 1-pixel line by intersecting a line with a grid.

--- a/WallsAndHoles/newtiletemplatesetdialog.cpp
+++ b/WallsAndHoles/newtiletemplatesetdialog.cpp
@@ -1,0 +1,67 @@
+#include "newtiletemplatesetdialog.h"
+
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+
+NewTileTemplateSetDialog::NewTileTemplateSetDialog(QWidget *parent)
+    : QDialog(parent)
+    , mOk(new QPushButton("Ok", this))
+    , mCancel(new QPushButton("Cancel", this))
+    , mFindFile(new QPushButton("...", this))
+    , mName(new QLineEdit("New Tile Template Set", this))
+    , mFilePath(new QLineEdit(this))
+{
+    setWindowTitle("New Tile Template Set");
+
+    QVBoxLayout *vLayout = new QVBoxLayout;
+    QHBoxLayout *hLayout = new QHBoxLayout;
+    hLayout->addWidget(new QLabel("Name: ", this));
+    hLayout->addWidget(mName);
+    vLayout->addLayout(hLayout);
+    hLayout = new QHBoxLayout;
+    hLayout->addWidget(new QLabel("File Dir: ", this));
+    hLayout->addWidget(mFilePath);
+    hLayout->addWidget(mFindFile);
+    vLayout->addLayout(hLayout);
+    hLayout = new QHBoxLayout;
+    hLayout->addWidget(mOk);
+    hLayout->addWidget(mCancel);
+    vLayout->addLayout(hLayout);
+
+    setLayout(vLayout);
+
+    connect(mOk, &QPushButton::clicked,
+            this, &NewTileTemplateSetDialog::ok);
+    connect(mCancel, &QPushButton::clicked,
+            this, &NewTileTemplateSetDialog::cancel);
+    connect(mFindFile, &QPushButton::clicked,
+            this, &NewTileTemplateSetDialog::findFile);
+}
+
+void NewTileTemplateSetDialog::ok()
+{
+    if (mFilePath->text().isEmpty()) {
+        QMessageBox mb;
+        mb.setText("Need to set a save location!");
+        mb.exec();
+        return;
+    }
+
+    result = NewTileTemplateSetData(mName->text(), mFilePath->text() + "/" + mName->text() + ".xml");
+    done(1);
+}
+
+void NewTileTemplateSetDialog::cancel()
+{
+    done(0);
+}
+
+void NewTileTemplateSetDialog::findFile()
+{
+    mFilePath->setText(QFileDialog::getExistingDirectory(this,
+                                                         "Save Location",
+                                                         "/home/"));
+}

--- a/WallsAndHoles/newtiletemplatesetdialog.h
+++ b/WallsAndHoles/newtiletemplatesetdialog.h
@@ -1,0 +1,39 @@
+#ifndef NEWTILETEMPLATESETDIALOG_H
+#define NEWTILETEMPLATESETDIALOG_H
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QPushButton>
+
+struct NewTileTemplateSetData
+{
+    QString name;
+    QString fileLocation;
+
+    NewTileTemplateSetData(QString n = "", QString fl = "") : name(n), fileLocation(fl) {}
+};
+
+class NewTileTemplateSetDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit NewTileTemplateSetDialog(QWidget *parent = 0);
+
+    NewTileTemplateSetData result;
+
+private slots:
+    void ok();
+    void cancel();
+    void findFile();
+
+private:
+    QPushButton *mOk;
+    QPushButton *mCancel;
+    QPushButton *mFindFile;
+
+    QLineEdit *mName;
+    QLineEdit *mFilePath;
+};
+
+#endif // NEWTILETEMPLATESETDIALOG_H

--- a/WallsAndHoles/rectbrushtool.cpp
+++ b/WallsAndHoles/rectbrushtool.cpp
@@ -1,7 +1,7 @@
 #include "rectbrushtool.h"
 
-RectBrushTool::RectBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawWith)
-    : AbstractShapeBrushTool(mapView, tileMap, drawWith)
+RectBrushTool::RectBrushTool(MapView *mapView, TileMap *tileMap)
+    : AbstractShapeBrushTool(mapView, tileMap)
 {
 
 }

--- a/WallsAndHoles/rectbrushtool.h
+++ b/WallsAndHoles/rectbrushtool.h
@@ -6,7 +6,7 @@
 
 class RectBrushTool : public AbstractShapeBrushTool {
 public:
-    RectBrushTool(MapView *mapView, TileMap *tileMap, SharedTileTemplate drawWith);
+    RectBrushTool(MapView *mapView, TileMap *tileMap);
 
     /// @brief Draws a rectangle.
     QVector<QPoint> getShape(int dx, int dy) const override;

--- a/WallsAndHoles/tilemapbrushtool.cpp
+++ b/WallsAndHoles/tilemapbrushtool.cpp
@@ -2,9 +2,8 @@
 
 #include <QDebug>
 
-TileMapBrushTool::TileMapBrushTool(TileMap *tileMap, SharedTileTemplate tileTemplate)
-    : AbstractTileMapTool(tileMap)
-    , mTileTemplate(tileTemplate) {}
+TileMapBrushTool::TileMapBrushTool(TileMap *tileMap)
+    : AbstractTileMapTool(tileMap) {}
 
 void TileMapBrushTool::cellActivated(int x, int y)
 {

--- a/WallsAndHoles/tilemapbrushtool.h
+++ b/WallsAndHoles/tilemapbrushtool.h
@@ -8,12 +8,9 @@
 class TileMapBrushTool : public AbstractTileMapTool
 {
 public:
-    TileMapBrushTool(TileMap *tileMap, SharedTileTemplate tileTemplate);
+    TileMapBrushTool(TileMap *tileMap);
 
     void cellActivated(int x, int y) override;
-
-private:
-    SharedTileTemplate mTileTemplate;
 };
 
 #endif // TILEMAPBRUSHTOOL_H

--- a/WallsAndHoles/tilemaptoolmanager.cpp
+++ b/WallsAndHoles/tilemaptoolmanager.cpp
@@ -28,3 +28,9 @@ void TileMapToolManager::cellReleased(int x, int y)
 {
     if (!mActiveTool.isNull()) tool2TileMapTool(mActiveTool)->cellReleased(x, y);
 }
+
+void TileMapToolManager::tileTemplateChanged(SharedTileTemplate tileTemplate)
+{
+    for (AbstractToolP tool : mTools)
+        static_cast<AbstractTileMapTool *>(tool.data())->setTileTemplate(tileTemplate);
+}

--- a/WallsAndHoles/tilemaptoolmanager.cpp
+++ b/WallsAndHoles/tilemaptoolmanager.cpp
@@ -10,8 +10,8 @@ TileMapToolManager::TileMapToolManager(QObject *parent)
 
 void TileMapToolManager::setTileMap(TileMap *tileMap)
 {
-    for (AbstractToolP t : mTools)
-        static_cast<AbstractTileMapTool *>(t.data())->setTileMap(tileMap);
+    for (AbstractToolP tool : mTools)
+        tool2TileMapTool(tool)->setTileMap(tileMap);
 }
 
 void TileMapToolManager::cellActivated(int x, int y)
@@ -32,5 +32,5 @@ void TileMapToolManager::cellReleased(int x, int y)
 void TileMapToolManager::tileTemplateChanged(SharedTileTemplate tileTemplate)
 {
     for (AbstractToolP tool : mTools)
-        static_cast<AbstractTileMapTool *>(tool.data())->setTileTemplate(tileTemplate);
+        tool2TileMapTool(tool)->setTileTemplate(tileTemplate);
 }

--- a/WallsAndHoles/tilemaptoolmanager.h
+++ b/WallsAndHoles/tilemaptoolmanager.h
@@ -21,6 +21,8 @@ public slots:
     void cellClicked(int x, int y);
     void cellReleased(int x, int y);
 
+    void tileTemplateChanged(SharedTileTemplate tileTemplate);
+
 private:
     using ToolManager::registerTool;
     using ToolManager::mousePressEvent;

--- a/WallsAndHoles/tiletemplate.cpp
+++ b/WallsAndHoles/tiletemplate.cpp
@@ -1,10 +1,13 @@
 #include "tiletemplate.h"
 
-TileTemplate::TileTemplate(float height,
+TileTemplate::TileTemplate(QColor color,
+                           QString name,
+                           float height,
                            float thickness,
-                           QVector2D position, QColor color,
+                           QVector2D position,
                            QObject *parent)
     : QObject(parent)
+    , mName(name)
     , mHeight(height)
     , mThickness(thickness)
     , mPosition(position)
@@ -12,22 +15,30 @@ TileTemplate::TileTemplate(float height,
 
 void TileTemplate::setHeight(float height)
 {
+    if (height == mHeight) return;
+
     mHeight = height;
 
     emit exclusivePropertyChanged();
+    emit changed();
 }
 
 void TileTemplate::setThickness(float thickness)
 {
+    if (thickness == mThickness) return;
+
     Q_ASSERT(thickness > 0 && thickness <= 1);
 
     mThickness = thickness;
 
     emit thicknessChanged();
+    emit changed();
 }
 
 void TileTemplate::setPosition(QVector2D position)
 {
+    if (position == mPosition) return;
+
     Q_ASSERT(position.x() > 0
              && position.x() < 1
              && position.y() > 0
@@ -36,6 +47,7 @@ void TileTemplate::setPosition(QVector2D position)
     mPosition = position;
 
     emit positionChanged();
+    emit changed();
 }
 
 void TileTemplate::setColor(QColor color)
@@ -43,4 +55,5 @@ void TileTemplate::setColor(QColor color)
     mColor = color;
 
     emit exclusivePropertyChanged();
+    emit changed();
 }

--- a/WallsAndHoles/tiletemplate.h
+++ b/WallsAndHoles/tiletemplate.h
@@ -13,10 +13,11 @@ class TileTemplate : public QObject
     Q_OBJECT
 
 public:
-    explicit TileTemplate(float height = 0,
+    explicit TileTemplate(QColor color = Qt::white,
+                          QString name = "New Tile Template",
+                          float height = 0,
                           float thickness = 1,
                           QVector2D position = QVector2D(0.5, 0.5),
-                          QColor color = Qt::white,
                           QObject *parent = nullptr);
 
     void setHeight(float height);
@@ -26,6 +27,9 @@ public:
     void setPosition(QVector2D position);
 
     void setColor(QColor color);
+
+    QString name() const { return mName; }
+    void setName(QString name) { mName = name; emit changed(); }
 
     float height() const { return mHeight; }
     float thickness() const { return mThickness; }
@@ -40,7 +44,12 @@ signals:
     void thicknessChanged();
     void positionChanged();
 
+    //emited anytime anything which needs to be saved changes
+    void changed();
+
 private:
+    QString mName;
+
     float mHeight;
     float mThickness;
     QVector2D mPosition;

--- a/WallsAndHoles/tiletemplateeditor.cpp
+++ b/WallsAndHoles/tiletemplateeditor.cpp
@@ -1,0 +1,186 @@
+#include "tiletemplateeditor.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+TileTemplateEditor::TileTemplateEditor(QWidget *parent)
+    : QWidget(parent)
+    , mNameLable(new QLabel(tr("Name"), this))
+    , mName(new QLineEdit(this))
+    , mHeightLable(new QLabel(tr("Height"), this))
+    , mHeight(new QDoubleSpinBox(this))
+    , mThicknessLable(new QLabel(tr("Thickness"), this))
+    , mThickness(new QDoubleSpinBox(this))
+    , mXPositionLabel(new QLabel(tr("X Position"), this))
+    , mXPosition(new QDoubleSpinBox(this))
+    , mYPositionLabel(new QLabel(tr("Y Position"), this))
+    , mYPosition(new QDoubleSpinBox(this))
+    , mTileTemplate(nullptr)
+    , mImEditing(false)
+{
+    // TODO define height range somewhere
+    mHeight->setRange(-1000, 1000);
+    mThickness->setRange(0.01, 1);
+    mXPosition->setRange(0, 1);
+    mYPosition->setRange(0, 1);
+
+    QHBoxLayout *hLayout = new QHBoxLayout;
+    QVBoxLayout *vLayout = new QVBoxLayout;
+
+    vLayout->addWidget(mNameLable);
+    vLayout->addWidget(mHeightLable);
+    vLayout->addWidget(mThicknessLable);
+    vLayout->addWidget(mXPositionLabel);
+    vLayout->addWidget(mYPositionLabel);
+
+    hLayout->addLayout(vLayout);
+
+    vLayout = new QVBoxLayout;
+    vLayout->addWidget(mName);
+    vLayout->addWidget(mHeight);
+    vLayout->addWidget(mThickness);
+    vLayout->addWidget(mXPosition);
+    vLayout->addWidget(mYPosition);
+
+    hLayout->addLayout(vLayout);
+
+    setLayout(hLayout);
+
+    connect(mName, &QLineEdit::textChanged,
+            this, &TileTemplateEditor::nameChanged);
+    connect(mHeight, SIGNAL(valueChanged(double)),
+            this, SLOT(heightChanged(double)));
+    connect(mThickness, SIGNAL(valueChanged(double)),
+            this, SLOT(thicknessChanged(double)));
+    connect(mXPosition, SIGNAL(valueChanged(double)),
+            this, SLOT(xPositionChanged(double)));
+    connect(mYPosition, SIGNAL(valueChanged(double)),
+            this, SLOT(yPositionChanged(double)));
+
+    setUpEditor();
+}
+
+void TileTemplateEditor::tileTemplateChanged(SharedTileTemplate tileTemplate)
+{
+    disconnect(mTileTemplate.data());
+
+    mTileTemplate = tileTemplate;
+    if (!mTileTemplate.isNull()) {
+        connect(mTileTemplate.data(), &TileTemplate::changed,
+                this, &TileTemplateEditor::tileTemplatePropertyChanged);
+    }
+
+    setUpEditor();
+}
+
+void TileTemplateEditor::tileTemplatePropertyChanged()
+{
+    if (!mImEditing)
+        setUpEditor();
+}
+
+void TileTemplateEditor::nameChanged(QString value)
+{
+    if (mTileTemplate.isNull())
+        return;
+
+    mImEditing = true;
+
+    mTileTemplate->setName(value);
+
+    mImEditing = false;
+}
+
+void TileTemplateEditor::heightChanged(double value)
+{
+    if (mTileTemplate.isNull())
+        return;
+
+    mImEditing = true;
+
+    mTileTemplate->setHeight(value);
+
+    mImEditing = false;
+}
+
+void TileTemplateEditor::thicknessChanged(double value)
+{
+    if (mTileTemplate.isNull())
+        return;
+
+    mImEditing = true;
+
+    mTileTemplate->setThickness(value);
+
+    mImEditing = false;
+}
+
+void TileTemplateEditor::xPositionChanged(double value)
+{
+    if (mTileTemplate.isNull())
+        return;
+
+    mImEditing = true;
+
+    QVector2D pos = mTileTemplate->position();
+    pos.setX(value);
+    mTileTemplate->setPosition(pos);
+
+    mImEditing = false;
+}
+
+void TileTemplateEditor::yPositionChanged(double value)
+{
+    if (mTileTemplate.isNull())
+        return;
+
+    mImEditing = true;
+
+    QVector2D pos = mTileTemplate->position();
+    pos.setY(value);
+    mTileTemplate->setPosition(pos);
+
+    mImEditing = false;
+}
+
+void TileTemplateEditor::setUpEditor()
+{
+    if (mTileTemplate.isNull()) {
+        mName->setText("");
+        mHeight->setValue(0);
+        mThickness->setValue(1);
+        mXPosition->setValue(0.5);
+        mYPosition->setValue(0.5);
+
+        mName->setEnabled(false);
+        mHeight->setEnabled(false);
+        mThickness->setEnabled(false);
+        mXPosition->setEnabled(false);
+        mYPosition->setEnabled(false);
+    } else {
+        //otherwise changed slots are called redundantly.
+        mName->blockSignals(true);
+        mHeight->blockSignals(true);
+        mThickness->blockSignals(true);
+        mXPosition->blockSignals(true);
+        mYPosition->blockSignals(true);
+
+        mName->setText(mTileTemplate->name());
+        mHeight->setValue(mTileTemplate->height());
+        mThickness->setValue(mTileTemplate->thickness());
+        mXPosition->setValue(mTileTemplate->position().x());
+        mYPosition->setValue(mTileTemplate->position().y());
+
+        mName->setEnabled(true);
+        mHeight->setEnabled(true);
+        mThickness->setEnabled(true);
+        mXPosition->setEnabled(true);
+        mYPosition->setEnabled(true);
+
+        mName->blockSignals(false);
+        mHeight->blockSignals(false);
+        mThickness->blockSignals(false);
+        mXPosition->blockSignals(false);
+        mYPosition->blockSignals(false);
+    }
+}

--- a/WallsAndHoles/tiletemplateeditor.h
+++ b/WallsAndHoles/tiletemplateeditor.h
@@ -1,0 +1,56 @@
+#ifndef TILETEMPLATEEDITOR_H
+#define TILETEMPLATEEDITOR_H
+
+#include "tiletemplate.h"
+
+#include <QWidget>
+#include <QDoubleSpinBox>
+#include <QLineEdit>
+#include <QLabel>
+
+class TileTemplateEditor : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TileTemplateEditor(QWidget *parent = nullptr);
+
+public slots:
+    void tileTemplateChanged(SharedTileTemplate tileTemplate);
+
+private slots:
+    void tileTemplatePropertyChanged();
+
+    void nameChanged(QString value);
+    void heightChanged(double value);
+    void thicknessChanged(double value);
+    void xPositionChanged(double value);
+    void yPositionChanged(double value);
+    //void colorChange();
+
+private:
+    /**
+     * @brief setUpEditor
+     * Fills the editor with all the data from mTileTemplate
+     */
+    void setUpEditor();
+
+    QLabel *mNameLable;
+    QLineEdit *mName;
+    QLabel *mHeightLable;
+    QDoubleSpinBox *mHeight;
+    QLabel *mThicknessLable;
+    QDoubleSpinBox *mThickness;
+    QLabel *mXPositionLabel;
+    QDoubleSpinBox *mXPosition;
+    QLabel *mYPositionLabel;
+    QDoubleSpinBox *mYPosition;
+
+    SharedTileTemplate mTileTemplate;
+
+    //set to true when changes are being made within this editor
+    //to avoid loops caused by signals
+    bool mImEditing;
+};
+
+#endif // TILETEMPLATEEDITOR_H

--- a/WallsAndHoles/tiletemplateset.cpp
+++ b/WallsAndHoles/tiletemplateset.cpp
@@ -1,20 +1,130 @@
 #include "tiletemplateset.h"
 
-TileTemplateSet::TileTemplateSet(QObject *parent)
-    : QObject(parent) {}
+#include "xmltool.h"
 
-void TileTemplateSet::addTileTemplate(SharedTileTemplate tileTemplate)
+TileTemplateSet::TileTemplateSet(QString savePath,
+                                 QString name,
+                                 bool loadedFromFile,
+                                 QObject *parent)
+    : QAbstractItemModel(parent)
+    , mName(name)
+    , mSavePath(savePath)
+    , mSaved(loadedFromFile) {}
+
+void TileTemplateSet::addTileTemplate(SharedTileTemplate tileTemplate,  bool dontAffectSaveStatus)
 {
-    mTileTemplates.append(tileTemplate);
+    if (!dontAffectSaveStatus)
+        changed();
 
-    emit tileTemplateAdded(mTileTemplates.size() - 1);
+    beginInsertRows(QModelIndex(), size(), size());
+    mTileTemplates.append(tileTemplate);
+    endInsertRows();
+
+    connect(tileTemplate.data(), &TileTemplate::changed,
+            this, &TileTemplateSet::templateChanged);
 }
 
 void TileTemplateSet::removeTileTemplate(int index)
 {
     Q_ASSERT(index >= 0 && index < mTileTemplates.size());
 
-    mTileTemplates.removeAt(index);
+    changed();
 
-    emit tileTemplateRemoved(index);
+    beginRemoveRows(QModelIndex(), index, index);
+    mTileTemplates.removeAt(index);
+    endRemoveRows();
+}
+
+void TileTemplateSet::save()
+{
+    // TODO be loader when saving fails
+    if (XMLTool::saveTileTemplateSet(this) != 0)
+        return;
+
+    mSaved = true;
+    emit saveStateChanged(mSaved);
+}
+
+QModelIndex TileTemplateSet::index(int row, int, const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return QModelIndex();
+
+    return createIndex(row, 0);
+}
+
+QModelIndex TileTemplateSet::parent(const QModelIndex &) const
+{
+    return QModelIndex();
+}
+
+int TileTemplateSet::rowCount(const QModelIndex &parent) const
+{
+    if (!parent.isValid())
+        return size();
+
+    return 0;
+}
+
+int TileTemplateSet::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+
+    return 1;
+}
+
+QVariant TileTemplateSet::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    if (!index.parent().isValid()) {
+        switch (role) {
+        case Qt::EditRole:
+        case Qt::DisplayRole:
+            return mTileTemplates[index.row()]->name();
+        case Qt::DecorationRole:
+            return mTileTemplates[index.row()]->color();
+        case Qt::ToolTipRole:
+            return tr("A Tile Template");
+        }
+    }
+
+    return QVariant();
+}
+
+bool TileTemplateSet::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (data(index, role) != value) {
+        switch (role) {
+        case Qt::EditRole:
+            mTileTemplates[index.row()]->setName(value.toString());
+        default:
+            return false;
+        }
+
+        emit dataChanged(index, index, QVector<int>() << role);
+        return true;
+    }
+    return false;
+}
+
+Qt::ItemFlags TileTemplateSet::flags(const QModelIndex &index) const
+{
+    if (!index.isValid() || index.parent().isValid())
+        return Qt::NoItemFlags;
+
+    return Qt::ItemIsEditable
+            | Qt::ItemIsSelectable
+            | Qt::ItemIsEnabled;
+}
+
+void TileTemplateSet::changed()
+{
+    if (mSaved) {
+        emit saveStateChanged(false);
+    }
+
+    mSaved = false;
 }

--- a/WallsAndHoles/tiletemplateset.h
+++ b/WallsAndHoles/tiletemplateset.h
@@ -3,40 +3,84 @@
 
 #include "tiletemplate.h"
 
-#include <QObject>
-#include <QVector>
+#include <QAbstractItemModel>
+#include <QList>
 
-class TileTemplateSet : public QObject
+/**
+ * @brief The TileTemplateSet class
+ * Stores a list of tile templates. Also implements the item model
+ * for them.
+ */
+class TileTemplateSet : public QAbstractItemModel
 {
     Q_OBJECT
 
 public:
-    explicit TileTemplateSet(QObject *parent = nullptr);
+    explicit TileTemplateSet(QString savePath,
+                             QString name = "New Tile Template Set",
+                             bool loadedFromFile = false,
+                             QObject *parent = nullptr);
+
+    //General Items::
 
     //Adds the given tileTemplate to the end of the tileList
     //should pass new TileTemplate(...) to this
-    void addTileTemplate(SharedTileTemplate tileTemplate);
+    void addTileTemplate(SharedTileTemplate tileTemplate, bool dontAffectSaveStatus = false);
 
     //removes the tiletemplate at the specified index
     void removeTileTemplate(int index);
 
-    const QVector<SharedTileTemplate> &cTileTemplates() const { return mTileTemplates; }
-    QVector<SharedTileTemplate> &tileTemplates() { return mTileTemplates; }
+    SharedTileTemplate tileTemplateAt(int i) { return mTileTemplates[i]; }
+    const SharedTileTemplate &cTileTemplateAt(int i) const { return mTileTemplates[i]; }
+
+    QString name() const { return mName; }
+    void setName(QString name) { changed(); mName = name; }
+
+    int size() const { return mTileTemplates.size(); }
+
+    const QList<SharedTileTemplate> &cTileTemplates() const { return mTileTemplates; }
 
     const QString savePath() const { return mSavePath; }
     void setSavePath(QString path){ mSavePath = path; }
 
-signals:
-    void tileTemplateAdded(int tileId);
-    void tileTemplateRemoved(int tileId);
+    void save();
+    bool isSaved() const { return mSaved; }
 
-public slots:
+    //Model Functions::
+    QModelIndex index(int row, int,
+                      const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &) const override;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    // Editable:
+    bool setData(const QModelIndex &index, const QVariant &value,
+                 int role = Qt::EditRole) override;
+
+    Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+signals:
+    void saveStateChanged(bool state);
+
+private slots:
+    void templateChanged() { changed(); }
 
 private:
-    QVector<SharedTileTemplate> mTileTemplates;
+    //should be called whenever data needing to be saved changes
+    void changed();
+
+    QString mName;
+
+    QList<SharedTileTemplate> mTileTemplates;
 
     //default save path of this tileTempalteSet object
     QString mSavePath;
+
+    //whether or not the current state of this is saved. (made false when this is changed)
+    bool mSaved;
 };
 
 typedef QSharedPointer<TileTemplateSet> SharedTileTemplateSet;

--- a/WallsAndHoles/tiletemplatesetsview.cpp
+++ b/WallsAndHoles/tiletemplatesetsview.cpp
@@ -1,0 +1,216 @@
+#include "tiletemplatesetsview.h"
+
+#include "newtiletemplatesetdialog.h"
+#include "tiletemplateeditor.h"
+#include "xmltool.h"
+
+#include <QAction>
+#include <QDebug>
+#include <QVBoxLayout>
+#include <QToolBar>
+#include <QFileDialog>
+#include <QMessageBox>
+
+TileTemplateSetsView::TileTemplateSetsView(QWidget *parent)
+    : QWidget(parent)
+    , mTabs(new QTabWidget(this))
+{
+    mTabs->setTabPosition(QTabWidget::North);
+
+    connect(mTabs, &QTabWidget::currentChanged,
+            this, &TileTemplateSetsView::selectedTileTemplateChanged);
+
+    TileTemplateEditor *templateEditor = new TileTemplateEditor(this);
+    connect(this, &TileTemplateSetsView::tileTemplateChanged,
+            templateEditor, &TileTemplateEditor::tileTemplateChanged);
+
+    QToolBar *actionBar = new QToolBar(this);
+    actionBar->setFloatable(false);
+    actionBar->setMovable(false);
+    actionBar->addAction("Add Template Set", this, &TileTemplateSetsView::addTemplateSet);
+    actionBar->addAction("Remove Template Set", this, &TileTemplateSetsView::removeTemplateSet);
+    actionBar->addAction("Save Template Set", this, &TileTemplateSetsView::saveTemplateSet);
+    actionBar->addAction("Load Template Set", this, &TileTemplateSetsView::loadTemplateSet);
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(mTabs);
+    layout->addWidget(templateEditor);
+    layout->addWidget(actionBar);
+    setLayout(layout);
+}
+
+void TileTemplateSetsView::addTileTemplateSet(SharedTileTemplateSet tileTemplateSet)
+{
+    mTileTemplateSets.append(tileTemplateSet);
+
+    connect(tileTemplateSet.data(), &TileTemplateSet::saveStateChanged,
+            this, [this, tileTemplateSet](bool status){
+        tileTemplateSetSaveStatusChanged(tileTemplateSet, status);
+    });
+
+    QWidget *templateWidget = new QWidget(this);
+
+    QListView *templateList = new QListView(templateWidget);
+    templateList->setModel(tileTemplateSet.data());
+    connect(templateList->selectionModel(), &QItemSelectionModel::currentRowChanged,
+            this, &TileTemplateSetsView::selectedTileTemplateChanged);
+    mListViews.append(templateList);
+
+    QToolBar *actionBar = new QToolBar(templateWidget);
+    actionBar->setFloatable(false);
+    actionBar->setMovable(false);
+    actionBar->addAction("Add Template", this, &TileTemplateSetsView::addTemplate);
+    actionBar->addAction("Remove Template", this, &TileTemplateSetsView::removeTemplate);
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(templateList);
+    layout->addWidget(actionBar);
+
+    templateWidget->setLayout(layout);
+
+    QString name = tileTemplateSet->name();
+    if (!tileTemplateSet->isSaved())
+        name += "*";
+    mTabs->setCurrentIndex(mTabs->addTab(templateWidget, name));
+}
+
+void TileTemplateSetsView::removeCurrentTileTemplateSet()
+{
+    int curI = mTabs->currentIndex();
+    if (curI == -1) return;
+
+    QWidget *w = mTabs->currentWidget();
+    mTabs->removeTab(curI);
+    delete w;
+
+    emit tileTemplateSetAboutToBeRemoved(mTileTemplateSets[curI]);
+
+    mTileTemplateSets.removeAt(curI);
+    mListViews.removeAt(curI);
+}
+
+void TileTemplateSetsView::selectedTileTemplateChanged()
+{
+    int curTab = mTabs->currentIndex();
+    int templateId;
+
+    if (curTab == -1) {
+        templateId = -1;
+    } else {
+        const QModelIndex &index = mListViews[curTab]->selectionModel()->currentIndex();
+        if (index.isValid()) {
+            templateId = index.row();
+            if (templateId >= mTileTemplateSets[curTab]->size())
+                templateId = mTileTemplateSets[curTab]->size() - 1;
+        } else {
+            templateId = -1;
+        }
+    }
+
+    if (templateId != -1)
+        emit tileTemplateChanged(mTileTemplateSets[curTab]->tileTemplateAt(templateId));
+    else
+        emit tileTemplateChanged(nullptr);
+}
+
+void TileTemplateSetsView::addTemplate()
+{
+    int curTab = mTabs->currentIndex();
+    Q_ASSERT(curTab >= 0);
+
+    SharedTileTemplate newTemplate = SharedTileTemplate::create(QColor::fromHsv(qrand()%255, 255, 255));
+
+    mTileTemplateSets[curTab]->addTileTemplate(newTemplate);
+    mListViews[curTab]->selectionModel()->setCurrentIndex(mTileTemplateSets[curTab]->index(mTileTemplateSets[curTab]->size() - 1, 0),
+                                                          QItemSelectionModel::ClearAndSelect);
+}
+
+void TileTemplateSetsView::removeTemplate()
+{
+    int curTab = mTabs->currentIndex();
+    Q_ASSERT(curTab >= 0);
+
+    QItemSelectionModel *selectionModel = mListViews[curTab]->selectionModel();
+    const QModelIndex &curIndex = selectionModel->currentIndex();
+    Q_ASSERT(curIndex.isValid());
+
+    int row = curIndex.row();
+
+    SharedTileTemplate tileTemplate = mTileTemplateSets[curTab]->tileTemplateAt(row);
+
+    emit tileTemplateAboutToBeRemoved(tileTemplate);
+
+    mTileTemplateSets[curTab]->removeTileTemplate(row);
+
+    selectedTileTemplateChanged();
+}
+
+void TileTemplateSetsView::addTemplateSet()
+{
+    NewTileTemplateSetDialog dia;
+    if (dia.exec()) {
+        for (SharedTileTemplateSet ts : mTileTemplateSets) {
+            if (dia.result.fileLocation == ts->savePath()) {
+                QMessageBox mb;
+                mb.setText(tr("Tile Template Set already open at requested location."));
+                mb.exec();
+                return;
+            }
+        }
+
+        SharedTileTemplateSet newTTS = SharedTileTemplateSet::create(dia.result.fileLocation, dia.result.name);
+        addTileTemplateSet(newTTS);
+    }
+}
+
+void TileTemplateSetsView::removeTemplateSet()
+{
+    int curTab = mTabs->currentIndex();
+    Q_ASSERT(curTab >= 0);
+
+    // TODO add ability to abort remove
+
+    removeCurrentTileTemplateSet();
+}
+
+void TileTemplateSetsView::saveTemplateSet()
+{
+    int curTab = mTabs->currentIndex();
+    Q_ASSERT(curTab >= 0);
+
+    mTileTemplateSets[curTab]->save();
+}
+
+void TileTemplateSetsView::loadTemplateSet()
+{
+    QString path = QFileDialog::getOpenFileName(this,
+                                                tr("Load Tile Template Set"),
+                                                "/home/",
+                                                tr("XML files (*.xml)"));
+
+    for (SharedTileTemplateSet ts : mTileTemplateSets) {
+        if (path == ts->savePath()) {
+            QMessageBox mb;
+            mb.setText(tr("The requested file is already open."));
+            mb.exec();
+            return;
+        }
+    }
+
+    if (!path.isNull()) {
+        SharedTileTemplateSet newSet = XMLTool::openTileTemplateSet(path);
+        if (!newSet.isNull()) {
+            addTileTemplateSet(newSet);
+        }
+    }
+}
+
+void TileTemplateSetsView::tileTemplateSetSaveStatusChanged(SharedTileTemplateSet tileTemplateSet, bool status)
+{
+    int tab = mTileTemplateSets.indexOf(tileTemplateSet);
+
+    QString tabText = mTileTemplateSets[tab]->name();
+    if (!status)
+        tabText += "*";
+    mTabs->setTabText(tab, tabText);
+}

--- a/WallsAndHoles/tiletemplatesetsview.h
+++ b/WallsAndHoles/tiletemplatesetsview.h
@@ -1,0 +1,54 @@
+#ifndef TILETEMPLATESETSVIEW_H
+#define TILETEMPLATESETSVIEW_H
+
+#include "tiletemplateset.h"
+
+#include <QWidget>
+#include <QTabWidget>
+#include <QListView>
+
+/**
+ * @brief The TileTemplateSetsView class
+ * Stores and displays all open TileTemplateSets.
+ * Has a tool bar for saving/loading/creating sets,
+ * and modifying existing sets
+ */
+class TileTemplateSetsView : public QWidget
+{
+    Q_OBJECT
+
+public:
+    TileTemplateSetsView(QWidget *parent = nullptr);
+
+    void addTileTemplateSet(SharedTileTemplateSet tileTemplateSet);
+    void removeCurrentTileTemplateSet();
+
+    const QList<SharedTileTemplateSet> &tileTemplateSets() const { return mTileTemplateSets; }
+
+signals:
+    void tileTemplateChanged(SharedTileTemplate tileTemplate);
+
+    void tileTemplateAboutToBeRemoved(const SharedTileTemplate tileTemplate);
+    void tileTemplateSetAboutToBeRemoved(const SharedTileTemplateSet tileTemplateSet);
+
+private slots:
+    void selectedTileTemplateChanged();
+
+    void addTemplate();
+    void removeTemplate();
+
+    void addTemplateSet();
+    void removeTemplateSet();
+    void saveTemplateSet();
+    void loadTemplateSet();
+
+private:
+    void tileTemplateSetSaveStatusChanged(SharedTileTemplateSet tileTemplateSet, bool status);
+
+    QList<SharedTileTemplateSet> mTileTemplateSets;
+    QList<QListView *> mListViews;
+
+    QTabWidget *mTabs;
+};
+
+#endif // TILETEMPLATESETSVIEW_H

--- a/WallsAndHoles/xmltool.cpp
+++ b/WallsAndHoles/xmltool.cpp
@@ -124,31 +124,37 @@ SharedTileTemplateSet XMLTool::openTileTemplateSet(QString templateSetPath){
         //If token is StartElement - read it
         if(token == QXmlStreamReader::StartElement) {
             if(xmlReader.name() == "TileTemplateSet") {
-                templateSet = SharedTileTemplateSet::create();
+                templateSet = SharedTileTemplateSet::create(templateSetPath,
+                                                            xmlReader.attributes()[0].value().toString(),
+                                                            true);
             }
             if(xmlReader.name() == "TileTemplate") {
+                QString name;
                 float thickness;
                 float height;
                 QVector2D position;
                 QColor color;
                 foreach(const QXmlStreamAttribute &attr, xmlReader.attributes()) {
-                    if (attr.name().toString() == QString("Thickness")) {
+                    if (attr.name() == "Name")
+                        name = attr.value().toString();
+
+                    if (attr.name().toString() == QString("Thickness"))
                         thickness = attr.value().toFloat();
-                    }
-                    if (attr.name().toString() == QString("Height")) {
+
+                    if (attr.name().toString() == QString("Height"))
                         height = attr.value().toFloat();
-                    }
+
                     if (attr.name().toString() == QString("Position")) {
                         QStringList pos = attr.value().toString().split(',');
                         position[0] = pos[0].toFloat();
                         position[1] = pos[1].toFloat();
                     }
-                    if (attr.name().toString() == QString("Color")) {
+
+                    if (attr.name().toString() == QString("Color"))
                         color = QColor(attr.value().toString());
-                    }
                 }
-                SharedTileTemplate tileTemplate = SharedTileTemplate::create(height,thickness,position,color);
-                templateSet->addTileTemplate(tileTemplate);
+                SharedTileTemplate tileTemplate = SharedTileTemplate::create(color, name, height,thickness,position);
+                templateSet->addTileTemplate(tileTemplate, true);
             }
         }
     }
@@ -196,7 +202,7 @@ int XMLTool::saveTileMap(SharedTileMap tileMap, bool saveTemplates){
         attr.setValue(templateSets[i]->savePath());
         element.setAttributeNode(attr);
         root.appendChild(element);
-        if(saveTemplates){ XMLTool::saveTileTemplateSet(templateSets[i]); }
+        if(saveTemplates){ XMLTool::saveTileTemplateSet(templateSets[i].data()); }
     }
     for(int i=0; i<tiles.size().height(); i++){
         for(int j=0; j<tiles.size().width(); j++){
@@ -246,8 +252,8 @@ int XMLTool::saveTileMap(SharedTileMap tileMap, bool saveTemplates){
     return 0;
 }
 
-int XMLTool::saveTileTemplateSet(SharedTileTemplateSet templateSet){
-    const QVector<SharedTileTemplate> templatelist = templateSet->cTileTemplates();
+int XMLTool::saveTileTemplateSet(TileTemplateSet *templateSet){
+    const QList<SharedTileTemplate> templatelist = templateSet->cTileTemplates();
     QString templateSetPath = templateSet->savePath();
     QFile file(templateSetPath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
@@ -260,9 +266,15 @@ int XMLTool::saveTileTemplateSet(SharedTileTemplateSet templateSet){
     doc.appendChild(instruction);
 
     QDomElement root = doc.createElement( "TileTemplateSet" );
+    attr = doc.createAttribute("Name");
+    attr.setValue(templateSet->name());
+    root.setAttributeNode(attr);
     doc.appendChild(root);
     for(SharedTileTemplate temp: templatelist){
         element = doc.createElement("TileTemplate");
+        attr = doc.createAttribute("Name");
+        attr.setValue(temp->name());
+        element.setAttributeNode(attr);
         attr = doc.createAttribute("Height");
         attr.setValue(QString::number(temp->height()));
         element.setAttributeNode(attr);

--- a/WallsAndHoles/xmltool.h
+++ b/WallsAndHoles/xmltool.h
@@ -13,7 +13,7 @@ namespace XMLTool {
     SharedTileTemplateSet openTileTemplateSet(QString templateSetPath);
 
     int saveTileMap(SharedTileMap tileMap, bool saveTemplates = true);
-    int saveTileTemplateSet(SharedTileTemplateSet templateSet);
+    int saveTileTemplateSet(TileTemplateSet *templateSet);
 }
 
 #endif // XMLTOOL_H


### PR DESCRIPTION
Lots of changes to the TileTemplate pipeline.

Added TileTemplateSetsView which:
   Is a tab widget, one tab per TileTemplateSet that is loaded.
   Has buttons for adding/removing/saving/loading TileTemplateSets
   Has buttons for adding/removing TileTemplates
   Adds a editor for changing the properties of a TileTemplate

Selecting a TileTemplate sends a signal to the TileMapToolManager, which
updates every tool to use the selected Template.

Super cool!