### PR TITLE
Saving changes; And more!

### DIFF
--- a/WallsAndHoles/WallsAndHoles.pro
+++ b/WallsAndHoles/WallsAndHoles.pro
@@ -64,7 +64,8 @@ SOURCES += \
     ellipsebrushtool.cpp \
     mapoverlaycell.cpp \
     filltool.cpp \
-    tiletemplatesetsmanager.cpp
+    tiletemplatesetsmanager.cpp \
+    savabletiletemplateset.cpp
 
 HEADERS += \
     renderableobject.h \
@@ -111,7 +112,8 @@ HEADERS += \
     ellipsebrushtool.h \
     mapoverlaycell.h \
     filltool.h \
-    tiletemplatesetsmanager.h
+    tiletemplatesetsmanager.h \
+    savabletiletemplateset.h
 
 FORMS += \
     meshview.ui \

--- a/WallsAndHoles/WallsAndHoles.pro
+++ b/WallsAndHoles/WallsAndHoles.pro
@@ -63,7 +63,8 @@ SOURCES += \
     rectbrushtool.cpp \
     ellipsebrushtool.cpp \
     mapoverlaycell.cpp \
-    filltool.cpp
+    filltool.cpp \
+    tiletemplatesetsmanager.cpp
 
 HEADERS += \
     renderableobject.h \
@@ -109,7 +110,8 @@ HEADERS += \
     rectbrushtool.h \
     ellipsebrushtool.h \
     mapoverlaycell.h \
-    filltool.h
+    filltool.h \
+    tiletemplatesetsmanager.h
 
 FORMS += \
     meshview.ui \

--- a/WallsAndHoles/abstractshapebrushtool.cpp
+++ b/WallsAndHoles/abstractshapebrushtool.cpp
@@ -48,7 +48,12 @@ void AbstractShapeBrushTool::drawOverlay(int endX, int endY) {
 
     QGraphicsScene *scene = mMapView->scene();
 
-    QColor color = getTileTemplate()->color();
+    QColor color;
+    if (TileTemplate *t = getTileTemplate())
+        color = t->color();
+    else
+        color = Qt::black;
+
     color.setAlpha(100);
 
     QPoint start(mStartX, mStartY);

--- a/WallsAndHoles/abstracttilemaptool.h
+++ b/WallsAndHoles/abstracttilemaptool.h
@@ -22,7 +22,7 @@ public:
         toolTileMapChanged(prev);
     }
 
-    void setTileTemplate(SharedTileTemplate tileTemplate) { mTileTemplate = tileTemplate; }
+    void setTileTemplate(TileTemplate *tileTemplate) { mTileTemplate = tileTemplate; }
 
 
     /**
@@ -82,11 +82,11 @@ protected:
 
     TileMap *getTileMap() const { return mTileMap; }
 
-    SharedTileTemplate getTileTemplate() const { return mTileTemplate; }
+    TileTemplate *getTileTemplate() const { return mTileTemplate; }
 
 private:
     TileMap *mTileMap;
-    SharedTileTemplate mTileTemplate;
+    TileTemplate *mTileTemplate;
 
     using AbstractTool::mousePressEvent;
     using AbstractTool::mouseReleaseEvent;

--- a/WallsAndHoles/editor.cpp
+++ b/WallsAndHoles/editor.cpp
@@ -143,9 +143,9 @@ void Editor::saveMap()
                                                            tr("Save Files (*.xml)")));
     }
 
-    const QList<SharedTileTemplateSet> &tileTemplateSets = mTileTemplateSetsView->tileTemplateSets();
+    const QList<SavableTileTemplateSet *> &tileTemplateSets = mTileTemplateSetsView->tileTemplateSets();
 
-    for (SharedTileTemplateSet tts : tileTemplateSets)
+    for (SavableTileTemplateSet *tts : tileTemplateSets)
         tts->save();
 
     XMLTool::saveTileMap(mTileMap, tileTemplateSets);

--- a/WallsAndHoles/editor.cpp
+++ b/WallsAndHoles/editor.cpp
@@ -148,6 +148,11 @@ void Editor::loadMap()
     setTileMap(tileMap);
 }
 
+void Editor::closeMap()
+{
+    setTileMap(nullptr);
+}
+
 void Editor::exportMapMesh()
 {
     if (mMeshViewContainer == nullptr) {
@@ -168,13 +173,15 @@ void Editor::exportMapMesh()
 
 void Editor::setTileMap(TileMap *tileMap)
 {
-    // TODO SHOULD provide option to save old tileMap
-    delete mTileMap;
-
+    TileMap *pre = mTileMap;
     mTileMap = tileMap;
     mTileMapToolManager->setTileMap(mTileMap);
     mMapView->createMap(mTileMap);
     mTileTemplateSetManager->setTileMap(mTileMap);
+    if (mTileMap)
+        mTileTemplateSetsView->setDefaultTileTemplateSet(mTileMap->defaultTileTemplateSet());
+    else
+        mTileTemplateSetsView->setDefaultTileTemplateSet(nullptr);
 
     delete mMap2Mesh;
 
@@ -188,6 +195,9 @@ void Editor::setTileMap(TileMap *tileMap)
     // but that is BEFORE the above connection is made. Therefore, updateScene()
     // must be called manually here.
     makeNewScene();
+
+    // TODO SHOULD provide option to save old tileMap
+    delete pre;
 }
 
 void Editor::setUpMenuBar()
@@ -199,6 +209,7 @@ void Editor::setUpMenuBar()
     fileMenu->addAction(tr("New Map"), this, &Editor::newMap);
     fileMenu->addAction(tr("Save Map"), this, &Editor::saveMap);
     fileMenu->addAction(tr("Load Map"), this, &Editor::loadMap);
+    fileMenu->addAction(tr("Close Map"), this, &Editor::closeMap);
     fileMenu->addSeparator();
     fileMenu->addAction(tr("Export Map Mesh"), this, &Editor::exportMapMesh);
 }

--- a/WallsAndHoles/editor.cpp
+++ b/WallsAndHoles/editor.cpp
@@ -121,7 +121,7 @@ void Editor::saveMap()
         mTileMap->setSavePath(QFileDialog::getSaveFileName(mMainWindow,
                                                            tr("Save Map"),
                                                            "/home/",
-                                                           tr("Save Files (*.xml)")));
+                                                           tr("Save Files (*.wah)")));
     }
 
     mTileTemplateSetManager->saveAllTileTemplateSets();
@@ -134,7 +134,7 @@ void Editor::loadMap()
     QString fileName = QFileDialog::getOpenFileName(mMainWindow,
                                                     tr("Open Map"),
                                                     "/home/",
-                                                    tr("Open Files (*.xml)"));
+                                                    tr("Open Files (*.wah)"));
 
     TileMap *tileMap = XMLTool::openTileMap(fileName, mTileTemplateSetManager);
 

--- a/WallsAndHoles/editor.h
+++ b/WallsAndHoles/editor.h
@@ -9,6 +9,7 @@
 #include "map2mesh.h"
 #include "meshviewcontainer.h"
 #include "tiletemplatesetsview.h"
+#include "tiletemplatesetsmanager.h"
 
 #include <QObject>
 #include <QList>
@@ -41,6 +42,8 @@ public slots:
     void makeNewScene();
 
 private:
+    //sets mTileMap to tileMap, and updates everything accordingly
+    void setTileMap(TileMap *tileMap);
     void setUpMenuBar();
 
     QMainWindow *mMainWindow;
@@ -50,6 +53,7 @@ private:
 
     //TileMap data
     TileMap *mTileMap;
+    TileTemplateSetsManager *mTileTemplateSetManager;
     QRegion mTileMapSelectedRegion;
 
     //views

--- a/WallsAndHoles/editor.h
+++ b/WallsAndHoles/editor.h
@@ -34,6 +34,7 @@ public slots:
     void newMap();
     void saveMap();
     void loadMap();
+    void closeMap();
     void exportMapMesh();
 
     /**

--- a/WallsAndHoles/filltool.cpp
+++ b/WallsAndHoles/filltool.cpp
@@ -152,7 +152,12 @@ void FillTool::drawOverlay(int endX, int endY)
 
         updateSelection(endX, endY);
 
-        QColor color = getTileTemplate()->color();
+        QColor color;
+        if (TileTemplate *t = getTileTemplate())
+            color = t->color();
+        else
+            color = Qt::black;
+
         color.setAlpha(100);
 
         QGraphicsScene *scene = mMapView->scene();

--- a/WallsAndHoles/filltool.cpp
+++ b/WallsAndHoles/filltool.cpp
@@ -56,10 +56,11 @@ void FillTool::toolTileMapChanged(TileMap *prev)
 
     // Disconnect old connections.
     if (prev != nullptr)
-        getTileMap()->disconnect(this);
+        prev->disconnect(this);
 
     // Make new connections.
-    connect(getTileMap(), &TileMap::mapChanged, this, &FillTool::invalidateSelection);
+    if (getTileMap())
+        connect(getTileMap(), &TileMap::mapChanged, this, &FillTool::invalidateSelection);
 }
 
 

--- a/WallsAndHoles/filltool.cpp
+++ b/WallsAndHoles/filltool.cpp
@@ -34,7 +34,7 @@ void FillTool::cellClicked(int x, int y)
     disconnect(getTileMap(), &TileMap::mapChanged, this, &FillTool::invalidateSelection);
 
     // Fill it in.
-    SharedTileTemplate drawMaterial = getTileTemplate();
+    TileTemplate *drawMaterial = getTileTemplate();
     for (QPoint point : mSelection)
         getTileMap()->setTile(point.x(), point.y(), drawMaterial);
 

--- a/WallsAndHoles/map2mesh.cpp
+++ b/WallsAndHoles/map2mesh.cpp
@@ -9,15 +9,14 @@
 #include "m2mtilemesher.h"
 
 Map2Mesh::Map2Mesh(TileMap *tileMap, QObject *parent)
-    : QObject(parent),
-      mTileMap(tileMap)
+    : QObject(parent)
+    , mTileMap(tileMap)
 {
     remakeAll();
 
-
     // Connect the tile changed & map resized signals.
-    connect(tileMap, &TileMap::tileChanged, this, &Map2Mesh::tileChanged);
-    connect(tileMap, &TileMap::resized, this, &Map2Mesh::remakeAll);
+    connect(mTileMap, &TileMap::tileChanged, this, &Map2Mesh::tileChanged);
+    connect(mTileMap, &TileMap::resized, this, &Map2Mesh::remakeAll);
 }
 
 
@@ -30,7 +29,6 @@ QVector<QSharedPointer<RenderableObject>> Map2Mesh::getMeshes() const
 
     return meshes;
 }
-
 
 void Map2Mesh::tileChanged(int x, int y)
 {

--- a/WallsAndHoles/map2mesh.cpp
+++ b/WallsAndHoles/map2mesh.cpp
@@ -32,6 +32,9 @@ QVector<QSharedPointer<RenderableObject>> Map2Mesh::getMeshes() const
 
 void Map2Mesh::tileChanged(int x, int y)
 {
+    Q_UNUSED(x);
+    Q_UNUSED(y);
+
     if (!mInferScheduled) {
         mInferScheduled = true;
 

--- a/WallsAndHoles/map2mesh.cpp
+++ b/WallsAndHoles/map2mesh.cpp
@@ -12,11 +12,13 @@ Map2Mesh::Map2Mesh(TileMap *tileMap, QObject *parent)
     : QObject(parent)
     , mTileMap(tileMap)
 {
-    remakeAll();
+    if (mTileMap) {
+        remakeAll();
 
-    // Connect the tile changed & map resized signals.
-    connect(mTileMap, &TileMap::tileChanged, this, &Map2Mesh::tileChanged);
-    connect(mTileMap, &TileMap::resized, this, &Map2Mesh::remakeAll);
+        // Connect the tile changed & map resized signals.
+        connect(mTileMap, &TileMap::tileChanged, this, &Map2Mesh::tileChanged);
+        connect(mTileMap, &TileMap::resized, this, &Map2Mesh::remakeAll);
+    }
 }
 
 

--- a/WallsAndHoles/map2mesh.h
+++ b/WallsAndHoles/map2mesh.h
@@ -19,8 +19,6 @@ class Map2Mesh : public QObject {
     Q_OBJECT
 
 public:
-
-
     /**
      * @brief Creates the conversion object.
      * @param tilemap - The tilemap on which the conversion will happen.
@@ -33,7 +31,6 @@ public:
      */
     QVector<QSharedPointer<RenderableObject>> getMeshes() const;
 
-
 public slots:
     /**
      * @brief Modifies the mesh near the tile that changed.
@@ -42,28 +39,23 @@ public slots:
      */
     void tileChanged(int x, int y);
 
-
     /**
      * @brief Completely remakes all tile meshes.
      */
     void remakeAll();
 
-
 signals:
-
     /**
      * @brief Emitted when the output mesh is updated.
      */
     void mapMeshUpdated();
 
 protected:
-
     /**
      * @brief Figures out mTileProperties for all tiles, and updates meshes when
      * properties change.
      */
     void inferProperties();
-
 
     TileMap *mTileMap;
 

--- a/WallsAndHoles/mapview.cpp
+++ b/WallsAndHoles/mapview.cpp
@@ -66,6 +66,8 @@ void MapView::createMap(TileMap *tileMap)
 {
     clear();
 
+    if (!tileMap) return;
+
     QSize mapSize = tileMap->mapSize();
     mMapCells.resize(mapSize.width(), mapSize.height());
 

--- a/WallsAndHoles/newtiletemplatesetdialog.cpp
+++ b/WallsAndHoles/newtiletemplatesetdialog.cpp
@@ -50,7 +50,7 @@ void NewTileTemplateSetDialog::ok()
         return;
     }
 
-    result = NewTileTemplateSetData(mName->text(), mFilePath->text() + "/" + mName->text() + ".xml");
+    result = NewTileTemplateSetData(mName->text(), mFilePath->text() + "/" + mName->text() + ".wts");
     done(1);
 }
 

--- a/WallsAndHoles/savabletiletemplateset.cpp
+++ b/WallsAndHoles/savabletiletemplateset.cpp
@@ -1,0 +1,30 @@
+#include "savabletiletemplateset.h"
+
+#include "xmltool.h"
+
+SavableTileTemplateSet::SavableTileTemplateSet(QString savePath,
+                                               QString name,
+                                               bool loadedFromFile,
+                                               QObject *parent)
+    : TileTemplateSet(name, parent)
+    , mSavePath(savePath)
+    , mSaved(loadedFromFile) {}
+
+void SavableTileTemplateSet::save()
+{
+    // TODO be louder when saving fails
+    if (XMLTool::saveTileTemplateSet(this) != 0)
+        return;
+
+    mSaved = true;
+    emit saveStateChanged(mSaved);
+}
+
+void SavableTileTemplateSet::changed()
+{
+    if (mSaved) {
+        emit saveStateChanged(false);
+    }
+
+    mSaved = false;
+}

--- a/WallsAndHoles/savabletiletemplateset.h
+++ b/WallsAndHoles/savabletiletemplateset.h
@@ -1,0 +1,42 @@
+#ifndef SAVABLETILETEMPLATESET_H
+#define SAVABLETILETEMPLATESET_H
+
+#include "tiletemplateset.h"
+
+/**
+ * @brief The SavableTileTemplateSet class
+ * A TileTemplateSet which is tightly bound to a file.
+ * Needs to be used with any custom TileTemplateSet (anything
+ * other that default map tileTemplates).
+ */
+class SavableTileTemplateSet : public TileTemplateSet
+{
+    Q_OBJECT
+
+public:
+    explicit SavableTileTemplateSet(QString savePath,
+                                    QString name = "New Tile Template Set",
+                                    bool loadedFromFile = false,
+                                    QObject *parent = nullptr);
+
+    const QString savePath() const { return mSavePath; }
+    void setSavePath(QString path){ mSavePath = path; }
+
+    void save();
+    bool isSaved() const { return mSaved; }
+
+signals:
+    void saveStateChanged(bool state);
+
+protected:
+    void changed() override;
+
+private:
+    //default save path of this tileTempalteSet object
+    QString mSavePath;
+
+    //whether or not the current state of this is saved. (made false when this is changed)
+    bool mSaved;
+};
+
+#endif // SAVABLETILETEMPLATESET_H

--- a/WallsAndHoles/tile.cpp
+++ b/WallsAndHoles/tile.cpp
@@ -14,14 +14,7 @@ Tile::Tile(SharedTileTemplate tileTemplate,
     , mRelativeHeight(0)
     , mRelativePosition(QVector2D())
 {
-    if (!mTileTemplate.isNull()) {
-        connect(mTileTemplate.data(), &TileTemplate::exclusivePropertyChanged,
-                this, [this]{ emit tileChanged(mXPos, mYPos); });
-        connect(mTileTemplate.data(), &TileTemplate::thicknessChanged,
-                this, &Tile::templateThicknessChanged);
-        connect(mTileTemplate.data(), &TileTemplate::positionChanged,
-                this, &Tile::templatePositionChanged);
-    }
+    makeTemplateConnections();
 }
 
 float Tile::thickness() const
@@ -131,14 +124,25 @@ void Tile::resetTile(SharedTileTemplate newTileTemplate)
         mTileTemplate->disconnect(this);
 
     mTileTemplate = newTileTemplate;
+    makeTemplateConnections();
+
+    emit tileChanged(mXPos, mYPos);
+}
+
+void Tile::makeTemplateConnections()
+{
     if (!mTileTemplate.isNull()) {
         connect(mTileTemplate.data(), &TileTemplate::exclusivePropertyChanged,
-                this, [this]{ emit tileChanged(mXPos, mYPos); });
+                this, [this]{
+            emit tileChanged(mXPos, mYPos);
+        });
         connect(mTileTemplate.data(), &TileTemplate::thicknessChanged,
                 this, &Tile::templateThicknessChanged);
         connect(mTileTemplate.data(), &TileTemplate::positionChanged,
                 this, &Tile::templatePositionChanged);
+        connect(mTileTemplate.data(), &TileTemplate::pingTiles,
+                this, [this]{
+            emit tilePinged(mXPos, mYPos);
+        });
     }
-
-    emit tileChanged(mXPos, mYPos);
 }

--- a/WallsAndHoles/tile.cpp
+++ b/WallsAndHoles/tile.cpp
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 
-Tile::Tile(SharedTileTemplate tileTemplate,
+Tile::Tile(TileTemplate *tileTemplate,
                int xPos,
                int yPos,
                QObject *parent)
@@ -19,7 +19,7 @@ Tile::Tile(SharedTileTemplate tileTemplate,
 
 float Tile::thickness() const
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return mRelativeThickness + 1;
     else
         return mRelativeThickness + mTileTemplate->thickness();
@@ -27,7 +27,7 @@ float Tile::thickness() const
 
 float Tile::height() const
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return mRelativeHeight;
     else
         return mRelativeHeight + mTileTemplate->height();
@@ -35,7 +35,7 @@ float Tile::height() const
 
 QVector2D Tile::position() const
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return mRelativePosition + QVector2D(0.5, 0.5);
     else
         return mRelativePosition + mTileTemplate->position();
@@ -43,7 +43,7 @@ QVector2D Tile::position() const
 
 void Tile::setRelativeThickness(float relativeThickness)
 {
-    if (mTileTemplate.isNull()) {
+    if (mTileTemplate == nullptr) {
         mRelativeThickness = 0;
         emit tileChanged(mXPos, mYPos);
         return;
@@ -76,7 +76,7 @@ void Tile::setRelativeThickness(float relativeThickness)
 
 void Tile::setRelativeHeight(float relativeHeight)
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         relativeHeight = 0;
 
     mRelativeHeight = relativeHeight;
@@ -91,7 +91,7 @@ void Tile::setRelativePosition(QVector2D relavtivePosition)
              && relavtivePosition.y() < 0.5
              && relavtivePosition.y() > -0.5);
 
-    if (mTileTemplate.isNull()) {
+    if (mTileTemplate == nullptr) {
         mRelativePosition = QVector2D();
         emit tileChanged(mXPos, mYPos);
         return;
@@ -115,12 +115,12 @@ void Tile::setRelativePosition(QVector2D relavtivePosition)
     emit tileChanged(mXPos, mYPos);
 }
 
-void Tile::resetTile(SharedTileTemplate newTileTemplate)
+void Tile::resetTile(TileTemplate *newTileTemplate)
 {
     mRelativeThickness = mRelativeHeight = 0;
     mRelativePosition = QVector2D();
 
-    if (!mTileTemplate.isNull())
+    if (mTileTemplate != nullptr)
         mTileTemplate->disconnect(this);
 
     mTileTemplate = newTileTemplate;
@@ -131,16 +131,16 @@ void Tile::resetTile(SharedTileTemplate newTileTemplate)
 
 void Tile::makeTemplateConnections()
 {
-    if (!mTileTemplate.isNull()) {
-        connect(mTileTemplate.data(), &TileTemplate::exclusivePropertyChanged,
+    if (mTileTemplate != nullptr) {
+        connect(mTileTemplate, &TileTemplate::exclusivePropertyChanged,
                 this, [this]{
             emit tileChanged(mXPos, mYPos);
         });
-        connect(mTileTemplate.data(), &TileTemplate::thicknessChanged,
+        connect(mTileTemplate, &TileTemplate::thicknessChanged,
                 this, &Tile::templateThicknessChanged);
-        connect(mTileTemplate.data(), &TileTemplate::positionChanged,
+        connect(mTileTemplate, &TileTemplate::positionChanged,
                 this, &Tile::templatePositionChanged);
-        connect(mTileTemplate.data(), &TileTemplate::pingTiles,
+        connect(mTileTemplate, &TileTemplate::pingTiles,
                 this, [this]{
             emit tilePinged(mXPos, mYPos);
         });

--- a/WallsAndHoles/tile.h
+++ b/WallsAndHoles/tile.h
@@ -45,6 +45,7 @@ public:
 
 signals:
     void tileChanged(int x, int y);
+    void tilePinged(int x, int y);
 
 public slots:
     //by calling the respective set functions, it is ensured that the tile wont go out of bounds.
@@ -53,6 +54,8 @@ public slots:
     void templatePositionChanged() { setRelativeThickness(mRelativeThickness); }
 
 private:
+    void makeTemplateConnections();
+
     SharedTileTemplate mTileTemplate;
 
     const int mXPos;

--- a/WallsAndHoles/tile.h
+++ b/WallsAndHoles/tile.h
@@ -14,13 +14,13 @@ class Tile : public QObject
     Q_OBJECT
 
 public:
-    explicit Tile(SharedTileTemplate tileTemplate = nullptr,
+    explicit Tile(TileTemplate *tileTemplate = nullptr,
                   int xPos = -1,
                   int yPos = -1,
                   QObject *parent = nullptr);
 
-    bool hasTileTemplate() const { return !mTileTemplate.isNull(); }
-    SharedTileTemplate tileTemplate() const { return mTileTemplate; }
+    bool hasTileTemplate() const { return mTileTemplate != nullptr; }
+    TileTemplate *tileTemplate() const { return mTileTemplate; }
 
     float thickness() const;
     float height() const;
@@ -41,7 +41,7 @@ public:
      * Sets all relative values to zero,
      * and changes the tileTemplate to newTileTemplate
      */
-    void resetTile(SharedTileTemplate newTileTemplate);
+    void resetTile(TileTemplate *newTileTemplate);
 
 signals:
     void tileChanged(int x, int y);
@@ -56,7 +56,7 @@ public slots:
 private:
     void makeTemplateConnections();
 
-    SharedTileTemplate mTileTemplate;
+    TileTemplate *mTileTemplate;
 
     const int mXPos;
     const int mYPos;

--- a/WallsAndHoles/tilemap.cpp
+++ b/WallsAndHoles/tilemap.cpp
@@ -102,8 +102,10 @@ void TileMap::resizeMap(QSize newSize)
     emit resized();
 }
 
-bool TileMap::tileTemplateUsed(TileTemplate *tileTemplate)
+bool TileMap::isTileTemplateUsed(TileTemplate *tileTemplate)
 {
+    mPingingMutex.lock();
+
     if (!tileTemplate) return false;
 
     mTilePingReceiveMode = SetCheck;
@@ -115,11 +117,15 @@ bool TileMap::tileTemplateUsed(TileTemplate *tileTemplate)
     mTilePinged = false;
     mTilePingReceiveMode = None;
 
+    mPingingMutex.unlock();
+
     return result;
 }
 
-bool TileMap::tileTemplateSetUsed(TileTemplateSet *tileTemplateSet)
+bool TileMap::isTileTemplateSetUsed(TileTemplateSet *tileTemplateSet)
 {
+    mPingingMutex.lock();
+
     mTilePingReceiveMode = SetCheck;
     mTilePinged = false;
 
@@ -135,11 +141,15 @@ bool TileMap::tileTemplateSetUsed(TileTemplateSet *tileTemplateSet)
     mTilePinged = false;
     mTilePingReceiveMode = None;
 
+    mPingingMutex.unlock();
+
     return result;
 }
 
 void TileMap::removingTileTemplateSet(TileTemplateSet *tileTemplateSet)
 {
+    mPingingMutex.lock();
+
     mTilePingReceiveMode = Collect;
     mPingedTiles.clear();
 
@@ -152,6 +162,8 @@ void TileMap::removingTileTemplateSet(TileTemplateSet *tileTemplateSet)
 
     mPingedTiles.clear();
     mTilePingReceiveMode = None;
+
+    mPingingMutex.unlock();
 }
 
 void TileMap::tilePinged(int x, int y)

--- a/WallsAndHoles/tilemap.cpp
+++ b/WallsAndHoles/tilemap.cpp
@@ -104,6 +104,8 @@ void TileMap::resizeMap(QSize newSize)
 
 bool TileMap::tileTemplateUsed(TileTemplate *tileTemplate)
 {
+    if (!tileTemplate) return false;
+
     mTilePingReceiveMode = SetCheck;
     mTilePinged = false;
 
@@ -122,7 +124,8 @@ bool TileMap::tileTemplateSetUsed(TileTemplateSet *tileTemplateSet)
     mTilePinged = false;
 
     for (TileTemplate *t : tileTemplateSet->cTileTemplates()) {
-        t->emitTilePing();
+        if (t)
+            t->emitTilePing();
 
         if (mTilePinged)
             break;
@@ -141,7 +144,8 @@ void TileMap::removingTileTemplateSet(TileTemplateSet *tileTemplateSet)
     mPingedTiles.clear();
 
     for (TileTemplate *t : tileTemplateSet->cTileTemplates())
-        t->emitTilePing();
+        if (t)
+            t->emitTilePing();
 
     for (QSharedPointer<Tile> t : mPingedTiles)
         t->resetTile(nullptr);

--- a/WallsAndHoles/tilemap.cpp
+++ b/WallsAndHoles/tilemap.cpp
@@ -6,6 +6,7 @@ TileMap::TileMap(QSize mapSize,
                  QObject *parent)
     : QObject(parent)
     , mMap(mapSize.width(), mapSize.height())
+    , mDefaultTileTemplateSet(new TileTemplateSet("Map Tile Templates", this))
 {
     for (int x = 0; x < mMap.size().width(); ++x) {
         for (int y = 0; y < mMap.size().height(); ++y) {
@@ -17,12 +18,14 @@ TileMap::TileMap(QSize mapSize,
         }
     }
 
-
     // tileChanged() and resized() signals should always be followed by a mapChanged() signal
-    connect(this, &TileMap::tileChanged, this, [this] () { emit mapChanged(); });
-    connect(this, &TileMap::resized, this, [this] () { emit mapChanged(); });
-}
+    connect(this, &TileMap::tileChanged, this, &TileMap::mapChanged);
+    connect(this, &TileMap::resized, this, &TileMap::mapChanged);
 
+    //set up default tile templates. TODO this should be impacted by inital map properties.
+    mDefaultTileTemplateSet->addTileTemplate(nullptr); //For an eraser
+    mDefaultTileTemplateSet->addTileTemplate(new TileTemplate(Qt::gray, "Wall", 2));
+}
 
 Tile &TileMap::tileAt(int x, int y)
 {

--- a/WallsAndHoles/tilemap.cpp
+++ b/WallsAndHoles/tilemap.cpp
@@ -132,14 +132,29 @@ bool TileMap::tileTemplateSetUsed(TileTemplateSet *tileTemplateSet)
     return result;
 }
 
+void TileMap::removingTileTemplateSet(TileTemplateSet *tileTemplateSet)
+{
+    mTilePingReceiveMode = Collect;
+    mPingedTiles.clear();
+
+    for (TileTemplate *t : tileTemplateSet->cTileTemplates())
+        t->emitTilePing();
+
+    for (QSharedPointer<Tile> t : mPingedTiles)
+        t->resetTile(nullptr);
+
+    mPingedTiles.clear();
+    mTilePingReceiveMode = None;
+}
+
 void TileMap::tilePinged(int x, int y)
 {
-    Q_UNUSED(x);
-    Q_UNUSED(y);
-
     switch(mTilePingReceiveMode) {
     case SetCheck:
         mTilePinged = true;
+        break;
+    case Collect:
+        mPingedTiles.append(mMap(x, y));
         break;
     default: break;
     }

--- a/WallsAndHoles/tilemap.cpp
+++ b/WallsAndHoles/tilemap.cpp
@@ -49,7 +49,7 @@ const Array2D<QSharedPointer<Tile>> &TileMap::getArray2D() const
     return mMap;
 }
 
-void TileMap::setTile(int x, int y, SharedTileTemplate tileTemplate)
+void TileMap::setTile(int x, int y, TileTemplate *tileTemplate)
 {
     Q_ASSERT(x >= 0);
     Q_ASSERT(y >= 0);
@@ -99,7 +99,7 @@ void TileMap::resizeMap(QSize newSize)
     emit resized();
 }
 
-bool TileMap::tileTemplateUsed(SharedTileTemplate tileTemplate)
+bool TileMap::tileTemplateUsed(TileTemplate *tileTemplate)
 {
     mTilePingReceiveMode = SetCheck;
     mTilePinged = false;
@@ -113,12 +113,12 @@ bool TileMap::tileTemplateUsed(SharedTileTemplate tileTemplate)
     return result;
 }
 
-bool TileMap::tileTemplateSetUsed(SharedTileTemplateSet tileTemplateSet)
+bool TileMap::tileTemplateSetUsed(TileTemplateSet *tileTemplateSet)
 {
     mTilePingReceiveMode = SetCheck;
     mTilePinged = false;
 
-    for (SharedTileTemplate t : tileTemplateSet->cTileTemplates()) {
+    for (TileTemplate *t : tileTemplateSet->cTileTemplates()) {
         t->emitTilePing();
 
         if (mTilePinged)

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -77,6 +77,8 @@ public:
      */
     void removingTileTemplateSet(TileTemplateSet *tileTemplateSet);
 
+    TileTemplateSet *defaultTileTemplateSet() { return mDefaultTileTemplateSet; }
+
 public slots:
     void tilePinged(int x, int y);
 
@@ -111,6 +113,8 @@ private:
     //Should be carefully be set to false elsewhere
     bool mTilePinged;
     QVector<QSharedPointer<Tile>> mPingedTiles;
+
+    TileTemplateSet *mDefaultTileTemplateSet;
 };
 
 #endif // TILEMAP_H

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -31,7 +31,7 @@ public:
      */
     const Array2D<QSharedPointer<Tile>> &getArray2D() const;
 
-    void setTile(int x, int y, SharedTileTemplate tileTemplate);
+    void setTile(int x, int y, TileTemplate *tileTemplate);
 
     //sets this tile to the default
     void clearTile(int x, int y) { setTile(x, y, nullptr); }
@@ -58,7 +58,7 @@ public:
      * @param tileTemplate
      * The tile template to check.
      */
-    bool tileTemplateUsed(SharedTileTemplate tileTemplate);
+    bool tileTemplateUsed(TileTemplate *tileTemplate);
 
     /**
      * @brief tileTemplateSetUsed
@@ -67,7 +67,7 @@ public:
      * @param tileTemplateSet
      * The set to check
      */
-    bool tileTemplateSetUsed(SharedTileTemplateSet tileTemplateSet);
+    bool tileTemplateSetUsed(TileTemplateSet *tileTemplateSet);
 
 public slots:
     void tilePinged(int x, int y);

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -69,6 +69,14 @@ public:
      */
     bool tileTemplateSetUsed(TileTemplateSet *tileTemplateSet);
 
+    /**
+     * @brief removingTileTemplateSet
+     * Called when a tileTemplateSet is going to be removed.
+     * Any tiles using templates from the set will be cleared.
+     * @param tileTemplateSet
+     */
+    void removingTileTemplateSet(TileTemplateSet *tileTemplateSet);
+
 public slots:
     void tilePinged(int x, int y);
 
@@ -87,8 +95,9 @@ private:
      * How a tilePinged singnal should be received.
      */
     enum TilePingReceiveMode {
-        None,
-        SetCheck
+        None,     //No action taken on ping reception.
+        SetCheck, //Set mTilePinged to true on ping reception.
+        Collect   //Add the pinded tile to mPingedTiles.
     };
 
     //2D array of Tile*. If mMap[x][y]->isEmpty() then ground is shown
@@ -101,6 +110,7 @@ private:
     //set to true when mTilePingReceiveMode == SetCheck, and a tilePinged is received.
     //Should be carefully be set to false elsewhere
     bool mTilePinged;
+    QVector<QSharedPointer<Tile>> mPingedTiles;
 };
 
 #endif // TILEMAP_H

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -50,16 +50,27 @@ public:
     const QString savePath() const { return mSavePath; }
     void setSavePath(QString path){ mSavePath = path; }
 
-    //simply add a dependent templateSet for saving/reloading,
-    //run updateDepend to check if this dependent it really necessary
-    void setDepend(SharedTileTemplateSet templateSet){ mDependencies.push_back(templateSet); }
-    //remove all dependencies that are no longer used in this tilemap.
-    void updateDepend();
-
-    QVector<SharedTileTemplateSet> dependencies() const { return mDependencies; }
-
     const Array2D<QSharedPointer<Tile>> &cTiles() const { return mMap; }
 
+    /**
+     * @brief tileTemplateUsed
+     * Returns true if some tile in the map uses this tileTemplate
+     * @param tileTemplate
+     * The tile template to check.
+     */
+    bool tileTemplateUsed(SharedTileTemplate tileTemplate);
+
+    /**
+     * @brief tileTemplateSetUsed
+     * Returns true if some tile in the map uses any of the tileTemplates
+     * of the given set
+     * @param tileTemplateSet
+     * The set to check
+     */
+    bool tileTemplateSetUsed(SharedTileTemplateSet tileTemplateSet);
+
+public slots:
+    void tilePinged(int x, int y);
 
 signals:
     void tileChanged(int x, int y);
@@ -71,15 +82,25 @@ signals:
     void mapChanged();
 
 private:
+    /**
+     * @brief The TilePingReceiveMode enum
+     * How a tilePinged singnal should be received.
+     */
+    enum TilePingReceiveMode {
+        None,
+        SetCheck
+    };
+
     //2D array of Tile*. If mMap[x][y]->isEmpty() then ground is shown
     Array2D<QSharedPointer<Tile>> mMap;
 
-    //holding a reference to all tileTemplateSet that this tilemap depends on
-    QVector<SharedTileTemplateSet> mDependencies;
     //default save path of this tilemap object, can be changed when using "save as" command.
     QString mSavePath;
-};
 
-typedef QSharedPointer<TileMap> SharedTileMap;
+    TilePingReceiveMode mTilePingReceiveMode;
+    //set to true when mTilePingReceiveMode == SetCheck, and a tilePinged is received.
+    //Should be carefully be set to false elsewhere
+    bool mTilePinged;
+};
 
 #endif // TILEMAP_H

--- a/WallsAndHoles/tilemap.h
+++ b/WallsAndHoles/tilemap.h
@@ -9,6 +9,7 @@
 #include <QObject>
 #include <QSize>
 #include <QSharedPointer>
+#include <QMutex>
 
 class TileMap : public QObject
 {
@@ -58,7 +59,7 @@ public:
      * @param tileTemplate
      * The tile template to check.
      */
-    bool tileTemplateUsed(TileTemplate *tileTemplate);
+    bool isTileTemplateUsed(TileTemplate *tileTemplate);
 
     /**
      * @brief tileTemplateSetUsed
@@ -67,7 +68,7 @@ public:
      * @param tileTemplateSet
      * The set to check
      */
-    bool tileTemplateSetUsed(TileTemplateSet *tileTemplateSet);
+    bool isTileTemplateSetUsed(TileTemplateSet *tileTemplateSet);
 
     /**
      * @brief removingTileTemplateSet
@@ -115,6 +116,8 @@ private:
     QVector<QSharedPointer<Tile>> mPingedTiles;
 
     TileTemplateSet *mDefaultTileTemplateSet;
+
+    QMutex mPingingMutex;
 };
 
 #endif // TILEMAP_H

--- a/WallsAndHoles/tilemaptoolmanager.cpp
+++ b/WallsAndHoles/tilemaptoolmanager.cpp
@@ -39,7 +39,7 @@ void TileMapToolManager::mouseExitedMap()
     if (!mActiveTool.isNull()) tool2TileMapTool(mActiveTool)->mouseExitedMap();
 }
 
-void TileMapToolManager::tileTemplateChanged(SharedTileTemplate tileTemplate)
+void TileMapToolManager::tileTemplateChanged(TileTemplate *tileTemplate)
 {
     for (AbstractToolP tool : mTools)
         tool2TileMapTool(tool)->setTileTemplate(tileTemplate);

--- a/WallsAndHoles/tilemaptoolmanager.h
+++ b/WallsAndHoles/tilemaptoolmanager.h
@@ -23,7 +23,7 @@ public slots:
     void cellHovered(int x, int y);
     void mouseExitedMap();
 
-    void tileTemplateChanged(SharedTileTemplate tileTemplate);
+    void tileTemplateChanged(TileTemplate *tileTemplate);
 
 private:
     using ToolManager::registerTool;

--- a/WallsAndHoles/tiletemplate.h
+++ b/WallsAndHoles/tiletemplate.h
@@ -69,6 +69,4 @@ private:
     QColor mColor;
 };
 
-typedef QSharedPointer<TileTemplate> SharedTileTemplate;
-
 #endif // TILETEMPLATE_H

--- a/WallsAndHoles/tiletemplate.h
+++ b/WallsAndHoles/tiletemplate.h
@@ -37,6 +37,14 @@ public:
 
     QColor color() const { return mColor; }
 
+    /**
+     * @brief emitTilePing
+     * Sends a signal to all tiles using this template, which will
+     * be forwarded to the containing TileMap, and handled there.
+     * Useful for gathing all tiles used by this template.
+     */
+    void emitTilePing() { emit pingTiles(); }
+
 signals:
     //a property which has no affect on other properties (ie not thickness or position)
     //but rendering should be updated
@@ -46,6 +54,8 @@ signals:
 
     //emited anytime anything which needs to be saved changes
     void changed();
+
+    void pingTiles();
 
 private:
     QString mName;

--- a/WallsAndHoles/tiletemplateeditor.cpp
+++ b/WallsAndHoles/tiletemplateeditor.cpp
@@ -60,13 +60,13 @@ TileTemplateEditor::TileTemplateEditor(QWidget *parent)
     setUpEditor();
 }
 
-void TileTemplateEditor::tileTemplateChanged(SharedTileTemplate tileTemplate)
+void TileTemplateEditor::tileTemplateChanged(TileTemplate *tileTemplate)
 {
-    disconnect(mTileTemplate.data());
+    disconnect(mTileTemplate);
 
     mTileTemplate = tileTemplate;
-    if (!mTileTemplate.isNull()) {
-        connect(mTileTemplate.data(), &TileTemplate::changed,
+    if (mTileTemplate != nullptr) {
+        connect(mTileTemplate, &TileTemplate::changed,
                 this, &TileTemplateEditor::tileTemplatePropertyChanged);
     }
 
@@ -81,7 +81,7 @@ void TileTemplateEditor::tileTemplatePropertyChanged()
 
 void TileTemplateEditor::nameChanged(QString value)
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return;
 
     mImEditing = true;
@@ -93,7 +93,7 @@ void TileTemplateEditor::nameChanged(QString value)
 
 void TileTemplateEditor::heightChanged(double value)
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return;
 
     mImEditing = true;
@@ -105,7 +105,7 @@ void TileTemplateEditor::heightChanged(double value)
 
 void TileTemplateEditor::thicknessChanged(double value)
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return;
 
     mImEditing = true;
@@ -117,7 +117,7 @@ void TileTemplateEditor::thicknessChanged(double value)
 
 void TileTemplateEditor::xPositionChanged(double value)
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return;
 
     mImEditing = true;
@@ -131,7 +131,7 @@ void TileTemplateEditor::xPositionChanged(double value)
 
 void TileTemplateEditor::yPositionChanged(double value)
 {
-    if (mTileTemplate.isNull())
+    if (mTileTemplate == nullptr)
         return;
 
     mImEditing = true;
@@ -145,7 +145,7 @@ void TileTemplateEditor::yPositionChanged(double value)
 
 void TileTemplateEditor::setUpEditor()
 {
-    if (mTileTemplate.isNull()) {
+    if (mTileTemplate == nullptr) {
         mName->setText("");
         mHeight->setValue(0);
         mThickness->setValue(1);

--- a/WallsAndHoles/tiletemplateeditor.h
+++ b/WallsAndHoles/tiletemplateeditor.h
@@ -16,7 +16,7 @@ public:
     explicit TileTemplateEditor(QWidget *parent = nullptr);
 
 public slots:
-    void tileTemplateChanged(SharedTileTemplate tileTemplate);
+    void tileTemplateChanged(TileTemplate *tileTemplate);
 
 private slots:
     void tileTemplatePropertyChanged();
@@ -46,7 +46,7 @@ private:
     QLabel *mYPositionLabel;
     QDoubleSpinBox *mYPosition;
 
-    SharedTileTemplate mTileTemplate;
+    TileTemplate *mTileTemplate;
 
     //set to true when changes are being made within this editor
     //to avoid loops caused by signals

--- a/WallsAndHoles/tiletemplateset.cpp
+++ b/WallsAndHoles/tiletemplateset.cpp
@@ -9,6 +9,8 @@ TileTemplateSet::TileTemplateSet(QString name,
 
 void TileTemplateSet::addTileTemplate(TileTemplate *tileTemplate,  bool dontAffectSaveStatus)
 {
+    tileTemplate->setParent(this);
+
     if (!dontAffectSaveStatus)
         changed();
 

--- a/WallsAndHoles/tiletemplateset.cpp
+++ b/WallsAndHoles/tiletemplateset.cpp
@@ -2,16 +2,12 @@
 
 #include "xmltool.h"
 
-TileTemplateSet::TileTemplateSet(QString savePath,
-                                 QString name,
-                                 bool loadedFromFile,
+TileTemplateSet::TileTemplateSet(QString name,
                                  QObject *parent)
     : QAbstractItemModel(parent)
-    , mName(name)
-    , mSavePath(savePath)
-    , mSaved(loadedFromFile) {}
+    , mName(name) {}
 
-void TileTemplateSet::addTileTemplate(SharedTileTemplate tileTemplate,  bool dontAffectSaveStatus)
+void TileTemplateSet::addTileTemplate(TileTemplate *tileTemplate,  bool dontAffectSaveStatus)
 {
     if (!dontAffectSaveStatus)
         changed();
@@ -20,7 +16,7 @@ void TileTemplateSet::addTileTemplate(SharedTileTemplate tileTemplate,  bool don
     mTileTemplates.append(tileTemplate);
     endInsertRows();
 
-    connect(tileTemplate.data(), &TileTemplate::changed,
+    connect(tileTemplate, &TileTemplate::changed,
             this, &TileTemplateSet::templateChanged);
 }
 
@@ -33,16 +29,6 @@ void TileTemplateSet::removeTileTemplate(int index)
     beginRemoveRows(QModelIndex(), index, index);
     mTileTemplates.removeAt(index);
     endRemoveRows();
-}
-
-void TileTemplateSet::save()
-{
-    // TODO be loader when saving fails
-    if (XMLTool::saveTileTemplateSet(this) != 0)
-        return;
-
-    mSaved = true;
-    emit saveStateChanged(mSaved);
 }
 
 QModelIndex TileTemplateSet::index(int row, int, const QModelIndex &parent) const
@@ -118,13 +104,4 @@ Qt::ItemFlags TileTemplateSet::flags(const QModelIndex &index) const
     return Qt::ItemIsEditable
             | Qt::ItemIsSelectable
             | Qt::ItemIsEnabled;
-}
-
-void TileTemplateSet::changed()
-{
-    if (mSaved) {
-        emit saveStateChanged(false);
-    }
-
-    mSaved = false;
 }

--- a/WallsAndHoles/tiletemplateset.cpp
+++ b/WallsAndHoles/tiletemplateset.cpp
@@ -9,7 +9,8 @@ TileTemplateSet::TileTemplateSet(QString name,
 
 void TileTemplateSet::addTileTemplate(TileTemplate *tileTemplate,  bool dontAffectSaveStatus)
 {
-    tileTemplate->setParent(this);
+    if (tileTemplate)
+        tileTemplate->setParent(this);
 
     if (!dontAffectSaveStatus)
         changed();
@@ -18,8 +19,10 @@ void TileTemplateSet::addTileTemplate(TileTemplate *tileTemplate,  bool dontAffe
     mTileTemplates.append(tileTemplate);
     endInsertRows();
 
-    connect(tileTemplate, &TileTemplate::changed,
-            this, &TileTemplateSet::templateChanged);
+    if (tileTemplate) {
+        connect(tileTemplate, &TileTemplate::changed,
+                this, &TileTemplateSet::templateChanged);
+    }
 }
 
 void TileTemplateSet::removeTileTemplate(int index)
@@ -71,9 +74,15 @@ QVariant TileTemplateSet::data(const QModelIndex &index, int role) const
         switch (role) {
         case Qt::EditRole:
         case Qt::DisplayRole:
-            return mTileTemplates[index.row()]->name();
+            if (TileTemplate *t = mTileTemplates[index.row()])
+                return t->name();
+            else
+                return "Ground (Eraser)";
         case Qt::DecorationRole:
-            return mTileTemplates[index.row()]->color();
+            if (TileTemplate *t = mTileTemplates[index.row()])
+                return t->color();
+            else
+                return QColor(0,0,0);
         case Qt::ToolTipRole:
             return tr("A Tile Template");
         }
@@ -87,7 +96,8 @@ bool TileTemplateSet::setData(const QModelIndex &index, const QVariant &value, i
     if (data(index, role) != value) {
         switch (role) {
         case Qt::EditRole:
-            mTileTemplates[index.row()]->setName(value.toString());
+            if (TileTemplate *t = mTileTemplates[index.row()])
+                t->setName(value.toString());
         default:
             return false;
         }
@@ -103,7 +113,11 @@ Qt::ItemFlags TileTemplateSet::flags(const QModelIndex &index) const
     if (!index.isValid() || index.parent().isValid())
         return Qt::NoItemFlags;
 
-    return Qt::ItemIsEditable
-            | Qt::ItemIsSelectable
-            | Qt::ItemIsEnabled;
+    if (mTileTemplates[index.row()]) {
+        return Qt::ItemIsEditable
+                | Qt::ItemIsSelectable
+                | Qt::ItemIsEnabled;
+    } else {
+        return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    }
 }

--- a/WallsAndHoles/tiletemplateset.h
+++ b/WallsAndHoles/tiletemplateset.h
@@ -16,35 +16,27 @@ class TileTemplateSet : public QAbstractItemModel
     Q_OBJECT
 
 public:
-    explicit TileTemplateSet(QString savePath,
-                             QString name = "New Tile Template Set",
-                             bool loadedFromFile = false,
+    explicit TileTemplateSet(QString name = "New Tile Template Set",
                              QObject *parent = nullptr);
 
     //General Items::
 
     //Adds the given tileTemplate to the end of the tileList
     //should pass new TileTemplate(...) to this
-    void addTileTemplate(SharedTileTemplate tileTemplate, bool dontAffectSaveStatus = false);
+    void addTileTemplate(TileTemplate *tileTemplate, bool dontAffectSaveStatus = false);
 
     //removes the tiletemplate at the specified index
     void removeTileTemplate(int index);
 
-    SharedTileTemplate tileTemplateAt(int i) { return mTileTemplates[i]; }
-    const SharedTileTemplate &cTileTemplateAt(int i) const { return mTileTemplates[i]; }
+    TileTemplate *tileTemplateAt(int i) { return mTileTemplates[i]; }
+    const TileTemplate *cTileTemplateAt(int i) const { return mTileTemplates[i]; }
 
     QString name() const { return mName; }
     void setName(QString name) { changed(); mName = name; }
 
     int size() const { return mTileTemplates.size(); }
 
-    const QList<SharedTileTemplate> &cTileTemplates() const { return mTileTemplates; }
-
-    const QString savePath() const { return mSavePath; }
-    void setSavePath(QString path){ mSavePath = path; }
-
-    void save();
-    bool isSaved() const { return mSaved; }
+    const QList<TileTemplate *> &cTileTemplates() const { return mTileTemplates; }
 
     //Model Functions::
     QModelIndex index(int row, int,
@@ -62,26 +54,18 @@ public:
 
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
-signals:
-    void saveStateChanged(bool state);
-
 private slots:
     void templateChanged() { changed(); }
 
-private:
+protected:
     //should be called whenever data needing to be saved changes
-    void changed();
+    //To be used in sub classes
+    virtual void changed() {}
 
+private:
     QString mName;
 
-    QList<SharedTileTemplate> mTileTemplates;
-
-    //default save path of this tileTempalteSet object
-    QString mSavePath;
-
-    //whether or not the current state of this is saved. (made false when this is changed)
-    bool mSaved;
+    QList<TileTemplate *> mTileTemplates;
 };
 
-typedef QSharedPointer<TileTemplateSet> SharedTileTemplateSet;
 #endif // TILESET_H

--- a/WallsAndHoles/tiletemplatesetsmanager.cpp
+++ b/WallsAndHoles/tiletemplatesetsmanager.cpp
@@ -116,7 +116,7 @@ SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet(bool tryToR
     QString path = QFileDialog::getOpenFileName(nullptr,
                                                 tr("Load Tile Template Set"),
                                                 "/home/",
-                                                tr("XML files (*.xml)"));
+                                                tr("WTS files (*.wts)"));
 
     return loadTileTemplateSet(path, tryToRelocateOnFail);
 }

--- a/WallsAndHoles/tiletemplatesetsmanager.cpp
+++ b/WallsAndHoles/tiletemplatesetsmanager.cpp
@@ -1,6 +1,42 @@
 #include "tiletemplatesetsmanager.h"
 
-TileTemplateSetsManager::TileTemplateSetsManager(QObject *parent) : QObject(parent)
+TileTemplateSetsManager::TileTemplateSetsManager(TileMap *tileMap,
+                                                 QObject *parent)
+    : QObject(parent)
+    , mTileMap(tileMap) {}
+
+void TileTemplateSetsManager::newTileTemplateSet()
+{
+
+}
+
+void TileTemplateSetsManager::addTileTemplateSet(SavableTileTemplateSet *tileTemplateSet)
+{
+    tileTemplateSet->setParent(this);
+
+    mTileTemplateSets.append(tileTemplateSet);
+
+    emit tileTemplateSetAdded(tileTemplateSet);
+}
+
+bool TileTemplateSetsManager::removeTileTemplateSet(SavableTileTemplateSet *TileTemplateSet)
+{
+    int
+
+    emit tileTemplateSetAboutToBeRemoved(tileTe);
+}
+
+bool TileTemplateSetsManager::removeTileTemplateSet(int index)
+{
+
+}
+
+void TileTemplateSetsManager::saveAllTileTemplateSets()
+{
+
+}
+
+SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet(QString path)
 {
 
 }

--- a/WallsAndHoles/tiletemplatesetsmanager.cpp
+++ b/WallsAndHoles/tiletemplatesetsmanager.cpp
@@ -111,17 +111,17 @@ void TileTemplateSetsManager::saveAllTileTemplateSets()
         ts->save();
 }
 
-SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet()
+SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet(bool tryToRelocateOnFail)
 {
     QString path = QFileDialog::getOpenFileName(nullptr,
                                                 tr("Load Tile Template Set"),
                                                 "/home/",
                                                 tr("XML files (*.xml)"));
 
-    return loadTileTemplateSet(path);
+    return loadTileTemplateSet(path, tryToRelocateOnFail);
 }
 
-SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet(QString path)
+SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet(QString path, bool tryToRelocateOnFail)
 {
     for (SavableTileTemplateSet *ts : mTileTemplateSets)
         if (path == ts->savePath())
@@ -133,6 +133,17 @@ SavableTileTemplateSet *TileTemplateSetsManager::loadTileTemplateSet(QString pat
             addTileTemplateSet(newSet);
 
             return newSet;
+        } else if (tryToRelocateOnFail) {
+            QMessageBox mb;
+            mb.setText(QString("Failed to load Tile Template Set at:\n    %1\n"
+                               "Would you like to try to relocate the Tile Template Set?\n").arg(path));
+            mb.addButton("Relocate", QMessageBox::AcceptRole);
+            mb.addButton("Cancel", QMessageBox::RejectRole);
+
+            if (mb.exec() == 0) {
+                //relocate
+                return loadTileTemplateSet(true);
+            }
         }
     }
 

--- a/WallsAndHoles/tiletemplatesetsmanager.cpp
+++ b/WallsAndHoles/tiletemplatesetsmanager.cpp
@@ -56,7 +56,7 @@ bool TileTemplateSetsManager::removeTileTemplateSet(int index)
     bool removeFromMap = false;
 
     //if this template set is in use with the tileMap
-    if (mTileMap && mTileMap->tileTemplateSetUsed(tileTemplateSet)) {
+    if (mTileMap && mTileMap->isTileTemplateSetUsed(tileTemplateSet)) {
         //Prompt user saying the set is in use, and if it is removed,
         //then the tiles using templates from this set will be reset
         // TODO: They should have an option to replace with another template?

--- a/WallsAndHoles/tiletemplatesetsmanager.cpp
+++ b/WallsAndHoles/tiletemplatesetsmanager.cpp
@@ -1,0 +1,6 @@
+#include "tiletemplatesetsmanager.h"
+
+TileTemplateSetsManager::TileTemplateSetsManager(QObject *parent) : QObject(parent)
+{
+
+}

--- a/WallsAndHoles/tiletemplatesetsmanager.h
+++ b/WallsAndHoles/tiletemplatesetsmanager.h
@@ -2,7 +2,6 @@
 #define TILETEMPLATESETSMANAGER_H
 
 #include "tilemap.h"
-#include "tiletemplatesetsview.h"
 #include "savabletiletemplateset.h"
 
 #include <QObject>
@@ -44,7 +43,7 @@ public:
      * @param TileTemplateSet
      * @return
      */
-    bool removeTileTemplateSet(SavableTileTemplateSet *TileTemplateSet);
+    bool removeTileTemplateSet(SavableTileTemplateSet *tileTemplateSet);
 
     /**
      * @brief removeTileTemplateSet
@@ -77,7 +76,9 @@ public:
     SavableTileTemplateSet *loadTileTemplateSet(QString path);
 
     SavableTileTemplateSet *tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
-    const QList<SavableTileTemplateSet *> tileTemplateSets() { return mTileTemplateSets; }
+    const QList<SavableTileTemplateSet *> &tileTemplateSets() { return mTileTemplateSets; }
+
+    void setTileMap(TileMap *tileMap) { mTileMap = tileMap; }
 
 signals:
     /**
@@ -86,14 +87,14 @@ signals:
      * Either by loading, new dialog, or somewhere in code.
      * @param tileTemplateSet
      */
-    void tileTemplateSetAdded(TileTemplateSet *tileTemplateSet);
+    void tileTemplateSetAdded(SavableTileTemplateSet *tileTemplateSet);
 
     /**
      * @brief tileTemplateSetAboutToBeRemoved
      * emitted right before the given tileTemplateSet is removed and deleted.
      * @param tileTemplateSet
      */
-    void tileTemplateSetAboutToBeRemoved(TileTemplateSet *tileTemplateSet);
+    void tileTemplateSetAboutToBeRemoved(SavableTileTemplateSet *tileTemplateSet);
 
 private:
     TileMap *mTileMap;

--- a/WallsAndHoles/tiletemplatesetsmanager.h
+++ b/WallsAndHoles/tiletemplatesetsmanager.h
@@ -2,7 +2,7 @@
 #define TILETEMPLATESETSMANAGER_H
 
 #include "tilemap.h"
-#include "tiletemplateset.h"
+#include "savabletiletemplateset.h"
 
 #include <QObject>
 
@@ -24,7 +24,7 @@ public:
      * Adds the given tileTemplateSet to the application
      * @param tileTemplateSet
      */
-    void addTileTemplateSet(SharedTileTemplateSet tileTemplateSet);
+    void addTileTemplateSet(SavableTileTemplateSet *tileTemplateSet);
 
     /**
      * @brief removeTileTemplateSet
@@ -37,7 +37,7 @@ public:
      * @param TileTemplateSet
      * @return
      */
-    bool removeTileTemplateSet(SharedTileTemplateSet TileTemplateSet);
+    bool removeTileTemplateSet(SavableTileTemplateSet *TileTemplateSet);
 
     /**
      * @brief removeTileTemplateSet
@@ -60,13 +60,13 @@ public:
      * the user will be given dialogs to relocate the file.
      * @param path
      */
-    SharedTileTemplateSet loadTileTemplateSet(QString path);
+    SavableTileTemplateSet *loadTileTemplateSet(QString path);
 
-    SharedTileTemplateSet tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
-    const QList<SharedTileTemplateSet> tileTemplateSets() { return mTileTemplateSets; }
+    SavableTileTemplateSet *tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
+    const QList<SavableTileTemplateSet *> tileTemplateSets() { return mTileTemplateSets; }
 
 private:
-    QList<SharedTileTemplateSet> mTileTemplateSets;
+    QList<SavableTileTemplateSet *> mTileTemplateSets;
 
     TileMap *mTileMap;
 };

--- a/WallsAndHoles/tiletemplatesetsmanager.h
+++ b/WallsAndHoles/tiletemplatesetsmanager.h
@@ -2,6 +2,7 @@
 #define TILETEMPLATESETSMANAGER_H
 
 #include "tilemap.h"
+#include "tiletemplatesetsview.h"
 #include "savabletiletemplateset.h"
 
 #include <QObject>
@@ -17,7 +18,13 @@ class TileTemplateSetsManager : public QObject
     Q_OBJECT
 
 public:
-    explicit TileTemplateSetsManager(QObject *parent = nullptr);
+    explicit TileTemplateSetsManager(TileMap *tileMap = nullptr, QObject *parent = nullptr);
+
+    /**
+     * @brief newTileTemplateSet
+     * Opens dialogs to create a new tileTemplateSet
+     */
+    void newTileTemplateSet();
 
     /**
      * @brief addTileTemplateSet
@@ -55,6 +62,13 @@ public:
 
     /**
      * @brief loadTileTemplateSet
+     * Opens dialogs to locate the templateSet to load, then loads it
+     * @return
+     */
+    SavableTileTemplateSet *loadTileTemplateSet();
+
+    /**
+     * @brief loadTileTemplateSet
      * Loads a tileTemplateSet at the given path.
      * If the file can't be loaded for any reason,
      * the user will be given dialogs to relocate the file.
@@ -65,10 +79,26 @@ public:
     SavableTileTemplateSet *tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
     const QList<SavableTileTemplateSet *> tileTemplateSets() { return mTileTemplateSets; }
 
-private:
-    QList<SavableTileTemplateSet *> mTileTemplateSets;
+signals:
+    /**
+     * @brief tileTemplateSetAdded
+     * Emitted whenever a new TileTemplateSet is added to the manager:
+     * Either by loading, new dialog, or somewhere in code.
+     * @param tileTemplateSet
+     */
+    void tileTemplateSetAdded(TileTemplateSet *tileTemplateSet);
 
+    /**
+     * @brief tileTemplateSetAboutToBeRemoved
+     * emitted right before the given tileTemplateSet is removed and deleted.
+     * @param tileTemplateSet
+     */
+    void tileTemplateSetAboutToBeRemoved(TileTemplateSet *tileTemplateSet);
+
+private:
     TileMap *mTileMap;
+
+    QList<SavableTileTemplateSet *> mTileTemplateSets;
 };
 
 #endif // TILETEMPLATESETSMANAGER_H

--- a/WallsAndHoles/tiletemplatesetsmanager.h
+++ b/WallsAndHoles/tiletemplatesetsmanager.h
@@ -64,7 +64,7 @@ public:
      * Opens dialogs to locate the templateSet to load, then loads it
      * @return
      */
-    SavableTileTemplateSet *loadTileTemplateSet();
+    SavableTileTemplateSet *loadTileTemplateSet(bool tryToRelocateOnFail = false);
 
     /**
      * @brief loadTileTemplateSet
@@ -73,7 +73,7 @@ public:
      * the user will be given dialogs to relocate the file.
      * @param path
      */
-    SavableTileTemplateSet *loadTileTemplateSet(QString path);
+    SavableTileTemplateSet *loadTileTemplateSet(QString path, bool tryToRelocateOnFail = false);
 
     SavableTileTemplateSet *tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
     const QList<SavableTileTemplateSet *> &tileTemplateSets() { return mTileTemplateSets; }

--- a/WallsAndHoles/tiletemplatesetsmanager.h
+++ b/WallsAndHoles/tiletemplatesetsmanager.h
@@ -1,6 +1,7 @@
 #ifndef TILETEMPLATESETSMANAGER_H
 #define TILETEMPLATESETSMANAGER_H
 
+#include "tilemap.h"
 #include "tiletemplateset.h"
 
 #include <QObject>
@@ -8,7 +9,8 @@
 /**
  * @brief The TileTemplateSetsManager class
  * Handles the active tileTemplateSets of the application.
- * Can create dialogs to interact with the user
+ * Can create dialogs to interact with the user.
+ * May modify the attached TileMap when removing templateSets.
  */
 class TileTemplateSetsManager : public QObject
 {
@@ -38,16 +40,35 @@ public:
     bool removeTileTemplateSet(SharedTileTemplateSet TileTemplateSet);
 
     /**
+     * @brief removeTileTemplateSet
+     * Attempt to remove a templateSet at the given index.
+     * @param index
+     * @return
+     */
+    bool removeTileTemplateSet(int index);
+
+    /**
      * @brief saveAllTileTemplateSets
      * Saves all unsaved tileTemplateSets
      */
     void saveAllTileTemplateSets();
+
+    /**
+     * @brief loadTileTemplateSet
+     * Loads a tileTemplateSet at the given path.
+     * If the file can't be loaded for any reason,
+     * the user will be given dialogs to relocate the file.
+     * @param path
+     */
+    SharedTileTemplateSet loadTileTemplateSet(QString path);
 
     SharedTileTemplateSet tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
     const QList<SharedTileTemplateSet> tileTemplateSets() { return mTileTemplateSets; }
 
 private:
     QList<SharedTileTemplateSet> mTileTemplateSets;
+
+    TileMap *mTileMap;
 };
 
 #endif // TILETEMPLATESETSMANAGER_H

--- a/WallsAndHoles/tiletemplatesetsmanager.h
+++ b/WallsAndHoles/tiletemplatesetsmanager.h
@@ -1,0 +1,53 @@
+#ifndef TILETEMPLATESETSMANAGER_H
+#define TILETEMPLATESETSMANAGER_H
+
+#include "tiletemplateset.h"
+
+#include <QObject>
+
+/**
+ * @brief The TileTemplateSetsManager class
+ * Handles the active tileTemplateSets of the application.
+ * Can create dialogs to interact with the user
+ */
+class TileTemplateSetsManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit TileTemplateSetsManager(QObject *parent = nullptr);
+
+    /**
+     * @brief addTileTemplateSet
+     * Adds the given tileTemplateSet to the application
+     * @param tileTemplateSet
+     */
+    void addTileTemplateSet(SharedTileTemplateSet tileTemplateSet);
+
+    /**
+     * @brief removeTileTemplateSet
+     * Attempts to remove the given templateSet from the application.
+     * If any of the templates of the set are in use, the user will be
+     * presented with a dialog, if they confirm the removal, then any
+     * tiles using templates from the set will be erased.
+     * If the set is not saved, the user will be prompted to save the set
+     * before it is removed.
+     * @param TileTemplateSet
+     * @return
+     */
+    bool removeTileTemplateSet(SharedTileTemplateSet TileTemplateSet);
+
+    /**
+     * @brief saveAllTileTemplateSets
+     * Saves all unsaved tileTemplateSets
+     */
+    void saveAllTileTemplateSets();
+
+    SharedTileTemplateSet tileTemplateSetAt(int i) { return mTileTemplateSets[i]; }
+    const QList<SharedTileTemplateSet> tileTemplateSets() { return mTileTemplateSets; }
+
+private:
+    QList<SharedTileTemplateSet> mTileTemplateSets;
+};
+
+#endif // TILETEMPLATESETSMANAGER_H

--- a/WallsAndHoles/tiletemplatesetsview.cpp
+++ b/WallsAndHoles/tiletemplatesetsview.cpp
@@ -83,8 +83,6 @@ void TileTemplateSetsView::removeCurrentTileTemplateSet()
     mTabs->removeTab(curI);
     delete w;
 
-    emit tileTemplateSetAboutToBeRemoved(mTileTemplateSets[curI]);
-
     mTileTemplateSets.removeAt(curI);
     mListViews.removeAt(curI);
 }
@@ -140,10 +138,6 @@ void TileTemplateSetsView::removeTemplate()
     Q_ASSERT(curIndex.isValid());
 
     int row = curIndex.row();
-
-    TileTemplate *tileTemplate = mTileTemplateSets[curTab]->tileTemplateAt(row);
-
-    emit tileTemplateAboutToBeRemoved(tileTemplate);
 
     mTileTemplateSets[curTab]->removeTileTemplate(row);
 

--- a/WallsAndHoles/tiletemplatesetsview.h
+++ b/WallsAndHoles/tiletemplatesetsview.h
@@ -2,6 +2,7 @@
 #define TILETEMPLATESETSVIEW_H
 
 #include "savabletiletemplateset.h"
+#include "tiletemplatesetsmanager.h"
 
 #include <QWidget>
 #include <QTabWidget>
@@ -18,17 +19,16 @@ class TileTemplateSetsView : public QWidget
     Q_OBJECT
 
 public:
-    TileTemplateSetsView(QWidget *parent = nullptr);
-
-    void addTileTemplateSet(SavableTileTemplateSet *tileTemplateSet);
-    void removeCurrentTileTemplateSet();
-
-    const QList<SavableTileTemplateSet *> &tileTemplateSets() const { return mTileTemplateSets; }
+    explicit TileTemplateSetsView(TileTemplateSetsManager *tileTemplateSetsManage,
+                                  QWidget *parent = nullptr);
 
 signals:
     void tileTemplateChanged(TileTemplate *tileTemplate);
 
 private slots:
+    void tileTemplateSetAdded(SavableTileTemplateSet *tileTemplateSet);
+    void tileTemplateSetAboutToBeRemoved(SavableTileTemplateSet *tileTemplateSet);
+
     void selectedTileTemplateChanged();
 
     void addTemplate();
@@ -42,7 +42,7 @@ private slots:
 private:
     void tileTemplateSetSaveStatusChanged(SavableTileTemplateSet *tileTemplateSet, bool status);
 
-    QList<SavableTileTemplateSet *> mTileTemplateSets;
+    TileTemplateSetsManager *mTileTemplateSetsManager;
     QList<QListView *> mListViews;
 
     QTabWidget *mTabs;

--- a/WallsAndHoles/tiletemplatesetsview.h
+++ b/WallsAndHoles/tiletemplatesetsview.h
@@ -1,7 +1,7 @@
 #ifndef TILETEMPLATESETSVIEW_H
 #define TILETEMPLATESETSVIEW_H
 
-#include "tiletemplateset.h"
+#include "savabletiletemplateset.h"
 
 #include <QWidget>
 #include <QTabWidget>
@@ -20,16 +20,16 @@ class TileTemplateSetsView : public QWidget
 public:
     TileTemplateSetsView(QWidget *parent = nullptr);
 
-    void addTileTemplateSet(SharedTileTemplateSet tileTemplateSet);
+    void addTileTemplateSet(SavableTileTemplateSet *tileTemplateSet);
     void removeCurrentTileTemplateSet();
 
-    const QList<SharedTileTemplateSet> &tileTemplateSets() const { return mTileTemplateSets; }
+    const QList<SavableTileTemplateSet *> &tileTemplateSets() const { return mTileTemplateSets; }
 
 signals:
-    void tileTemplateChanged(SharedTileTemplate tileTemplate);
+    void tileTemplateChanged(TileTemplate *tileTemplate);
 
-    void tileTemplateAboutToBeRemoved(const SharedTileTemplate tileTemplate);
-    void tileTemplateSetAboutToBeRemoved(const SharedTileTemplateSet tileTemplateSet);
+    void tileTemplateAboutToBeRemoved(const TileTemplate *tileTemplate);
+    void tileTemplateSetAboutToBeRemoved(const SavableTileTemplateSet *tileTemplateSet);
 
 private slots:
     void selectedTileTemplateChanged();
@@ -43,9 +43,9 @@ private slots:
     void loadTemplateSet();
 
 private:
-    void tileTemplateSetSaveStatusChanged(SharedTileTemplateSet tileTemplateSet, bool status);
+    void tileTemplateSetSaveStatusChanged(SavableTileTemplateSet *tileTemplateSet, bool status);
 
-    QList<SharedTileTemplateSet> mTileTemplateSets;
+    QList<SavableTileTemplateSet *> mTileTemplateSets;
     QList<QListView *> mListViews;
 
     QTabWidget *mTabs;

--- a/WallsAndHoles/tiletemplatesetsview.h
+++ b/WallsAndHoles/tiletemplatesetsview.h
@@ -22,6 +22,8 @@ public:
     explicit TileTemplateSetsView(TileTemplateSetsManager *tileTemplateSetsManage,
                                   QWidget *parent = nullptr);
 
+    void setDefaultTileTemplateSet(TileTemplateSet *tileTemplateSet);
+
 signals:
     void tileTemplateChanged(TileTemplate *tileTemplate);
 
@@ -30,6 +32,7 @@ private slots:
     void tileTemplateSetAboutToBeRemoved(SavableTileTemplateSet *tileTemplateSet);
 
     void selectedTileTemplateChanged();
+    void defaultTileTemplateSelected(const QModelIndex &current);
 
     void addTemplate();
     void removeTemplate();
@@ -42,6 +45,8 @@ private slots:
 private:
     void tileTemplateSetSaveStatusChanged(SavableTileTemplateSet *tileTemplateSet, bool status);
 
+    TileTemplateSet *mDefaultTemplateSet;
+    QListView *mDefaultTemplateView;
     TileTemplateSetsManager *mTileTemplateSetsManager;
     QList<QListView *> mListViews;
 

--- a/WallsAndHoles/tiletemplatesetsview.h
+++ b/WallsAndHoles/tiletemplatesetsview.h
@@ -28,9 +28,6 @@ public:
 signals:
     void tileTemplateChanged(TileTemplate *tileTemplate);
 
-    void tileTemplateAboutToBeRemoved(const TileTemplate *tileTemplate);
-    void tileTemplateSetAboutToBeRemoved(const SavableTileTemplateSet *tileTemplateSet);
-
 private slots:
     void selectedTileTemplateChanged();
 

--- a/WallsAndHoles/xmltool.cpp
+++ b/WallsAndHoles/xmltool.cpp
@@ -9,12 +9,10 @@ TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsManager *tile
 {
     //load the file
     QFile file(tileMapPath);
-    if (!file.exists() || !file.open(QFile::ReadOnly | QFile::Text)) {
-        qDebug() << "Fail to open file:"+tileMapPath;
+    if (!file.exists() || !file.open(QFile::ReadOnly | QFile::Text))
         return nullptr;
-    }
-    QXmlStreamReader xmlReader(file.readAll());
 
+    QXmlStreamReader xmlReader(file.readAll());
     TileMap *tileMap;
 
     QVector<SavableTileTemplateSet *> loadedTileTemplateSets;
@@ -42,7 +40,7 @@ TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsManager *tile
             } else if (xmlReader.name() == "TileTemplateSet") {
                 QString path = xmlReader.attributes().first().value().toString();
 
-                SavableTileTemplateSet *templateSet = tileTemplateSetsManager->loadTileTemplateSet(path);
+                SavableTileTemplateSet *templateSet = tileTemplateSetsManager->loadTileTemplateSet(path, true);
 
                 if (templateSet == nullptr)
                     return nullptr;
@@ -76,6 +74,10 @@ TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsManager *tile
                     }
                 }
 
+                if (setId >= loadedTileTemplateSets.size()
+                        || templateId >= loadedTileTemplateSets[setId]->size())
+                    return nullptr;
+
                 TileTemplate *tileTemplate = loadedTileTemplateSets[setId]->tileTemplateAt(templateId);
 
                 Tile& tile = tileMap->tileAt(x,y);
@@ -104,10 +106,8 @@ SavableTileTemplateSet *XMLTool::openTileTemplateSet(QString templateSetPath)
 {
     //load the file
     QFile file(templateSetPath);
-    if (!file.exists() || !file.open(QFile::ReadOnly | QFile::Text)) {
-        qDebug() << "Fail to open file:"+templateSetPath;
+    if (!file.exists() || !file.open(QFile::ReadOnly | QFile::Text))
         return nullptr;
-    }
 
     QXmlStreamReader xmlReader(file.readAll());
     SavableTileTemplateSet *templateSet;

--- a/WallsAndHoles/xmltool.cpp
+++ b/WallsAndHoles/xmltool.cpp
@@ -210,7 +210,7 @@ int XMLTool::saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *>
 
     QVector<SavableTileTemplateSet *> usedTileTemplateSets;
     for (SavableTileTemplateSet *tts : tileTemplateSets) {
-        if (tileMap->tileTemplateSetUsed(tts)) {
+        if (tileMap->isTileTemplateSetUsed(tts)) {
             usedTileTemplateSets.append(tts);
 
             QDomElement templateSet = doc.createElement("TileTemplateSet");

--- a/WallsAndHoles/xmltool.cpp
+++ b/WallsAndHoles/xmltool.cpp
@@ -1,11 +1,11 @@
 #include "xmltool.h"
 
-#include "tiletemplatesetsview.h"
+#include "tiletemplatesetsmanager.h"
 
 #include <QDebug>
 #include <QMessageBox>
 
-TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsView *tileTemplateSetView)
+TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsManager *tileTemplateSetsManager)
 {
     //load the file
     QFile file(tileMapPath);
@@ -24,79 +24,60 @@ TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsView *tileTem
         // Read next element
         QXmlStreamReader::TokenType token = xmlReader.readNext();
         //If token is just StartDocument - go to next
-        if(token == QXmlStreamReader::StartDocument) {
-                continue;
-        }
+        if (token == QXmlStreamReader::StartDocument)
+            continue;
 
         //If token is StartElement - read it
-        if(token == QXmlStreamReader::StartElement) {
-            if(xmlReader.name() == "TileMap") {
+        if (token == QXmlStreamReader::StartElement) {
+            if (xmlReader.name() == "TileMap") {
                 QSize size;
                 foreach(const QXmlStreamAttribute &attr, xmlReader.attributes()) {
-                    if (attr.name().toString() == QString("width")) {
+                    if (attr.name() == "width")
                          size.setWidth(attr.value().toInt());
-                    }
-                    if (attr.name().toString() == QString("height")) {
+                    if (attr.name() == "height")
                          size.setHeight(attr.value().toInt());
-                    }
                 }
                 tileMap = new TileMap(size);
-            }
+                tileMap->setSavePath(tileMapPath);
+            } else if (xmlReader.name() == "TileTemplateSet") {
+                QString path = xmlReader.attributes().first().value().toString();
 
-            if(xmlReader.name()=="TileTemplateSet"){
-                SavableTileTemplateSet *templateSet;
-                foreach(const QXmlStreamAttribute &attr, xmlReader.attributes()) {
-                    if (attr.name().toString() == QString("SavePath")) {
-                        templateSet = XMLTool::openTileTemplateSet(attr.value().toString());
-                    }
-                }
-                if(templateSet==nullptr)
+                SavableTileTemplateSet *templateSet = tileTemplateSetsManager->loadTileTemplateSet(path);
+
+                if (templateSet == nullptr)
                     return nullptr;
 
-                tileTemplateSetView->addTileTemplateSet(templateSet);
                 loadedTileTemplateSets.append(templateSet);
-            }
-
-            if(xmlReader.name() == "Tile") {
+            } else if (xmlReader.name() == "Tile") {
                 float x;
                 float y;
-                int id;
-                TileTemplate *tileTemplate;
+                int setId = -1, templateId;
                 float relativeThickness;
                 float relativeHeight;
                 QVector2D relativePosition;
+
                 foreach (const QXmlStreamAttribute &attr, xmlReader.attributes()) {
-                    if(attr.name().toString() == QString("x")){
+                    if (attr.name() == "x") {
                         x = attr.value().toInt();
-                    }
-                    if(attr.name().toString() == QString("y")){
+                    } else if (attr.name() == "y") {
                         y = attr.value().toInt();
-                    }
-                    if(attr.name().toString() == QString("TemplateID")){
-                        id = attr.value().toInt();
-                    }
-                    if(attr.name().toString() == QString("RelativeThickness")){
+                    } else if (attr.name() == "templateSetId") {
+                        setId = attr.value().toInt();
+                    } else if (attr.name() == "templateId") {
+                        templateId = attr.value().toInt();
+                    } else if (attr.name() == "relativeThickness") {
                         relativeThickness = attr.value().toFloat();
-                    }
-                    if(attr.name().toString() == QString("RelativeHeight")){
+                    } else if (attr.name() == "relativeHeight") {
                         relativeHeight = attr.value().toFloat();
-                    }
-                    if(attr.name().toString() == QString("RelativePosition")){
+                    } else if (attr.name() == "relativePosition") {
                         QStringList pos = attr.value().toString().split(',');
                         relativePosition[0] = pos[0].toFloat();
                         relativePosition[1] = pos[1].toFloat();
                     }
                 }
 
-                for (SavableTileTemplateSet *set: loadedTileTemplateSets) {
-                    if (id >= set->size()) {
-                        id -= set->size();
-                        continue;
-                    } else {
-                        tileTemplate = set->cTileTemplates()[id];
-                        break;
-                    }
-                }
+                TileTemplate *tileTemplate = loadedTileTemplateSets[setId]->tileTemplateAt(templateId);
+
                 Tile& tile = tileMap->tileAt(x,y);
                 tile.resetTile(tileTemplate);
                 tile.setRelativeThickness(relativeThickness);
@@ -119,55 +100,52 @@ TileMap *XMLTool::openTileMap(QString tileMapPath, TileTemplateSetsView *tileTem
     return tileMap;
 }
 
-SavableTileTemplateSet *XMLTool::openTileTemplateSet(QString templateSetPath){
+SavableTileTemplateSet *XMLTool::openTileTemplateSet(QString templateSetPath)
+{
     //load the file
     QFile file(templateSetPath);
     if (!file.exists() || !file.open(QFile::ReadOnly | QFile::Text)) {
         qDebug() << "Fail to open file:"+templateSetPath;
         return nullptr;
     }
+
     QXmlStreamReader xmlReader(file.readAll());
     SavableTileTemplateSet *templateSet;
     //Parse the XML until we reach end of it
-    while(!xmlReader.atEnd() && !xmlReader.hasError()) {
+    while (!xmlReader.atEnd() && !xmlReader.hasError()) {
         // Read next element
         QXmlStreamReader::TokenType token = xmlReader.readNext();
         //If token is just StartDocument - go to next
-        if(token == QXmlStreamReader::StartDocument) {
-                continue;
-        }
+        if (token == QXmlStreamReader::StartDocument)
+            continue;
+
         //If token is StartElement - read it
-        if(token == QXmlStreamReader::StartElement) {
-            if(xmlReader.name() == "TileTemplateSet") {
+        if (token == QXmlStreamReader::StartElement) {
+            if (xmlReader.name() == "TileTemplateSet") {
                 templateSet = new SavableTileTemplateSet(templateSetPath,
                                                          xmlReader.attributes()[0].value().toString(),
                                                          true);
-            }
-            if(xmlReader.name() == "TileTemplate") {
+            } else if (xmlReader.name() == "TileTemplate") {
                 QString name;
                 float thickness;
                 float height;
                 QVector2D position;
                 QColor color;
-                foreach(const QXmlStreamAttribute &attr, xmlReader.attributes()) {
-                    if (attr.name() == "Name")
+                foreach (const QXmlStreamAttribute &attr, xmlReader.attributes()) {
+                    if (attr.name() == "name")
                         name = attr.value().toString();
-
-                    if (attr.name().toString() == QString("Thickness"))
+                    else if (attr.name() == "thickness")
                         thickness = attr.value().toFloat();
-
-                    if (attr.name().toString() == QString("Height"))
+                    else if (attr.name() == "height")
                         height = attr.value().toFloat();
-
-                    if (attr.name().toString() == QString("Position")) {
+                    else if (attr.name() == "position") {
                         QStringList pos = attr.value().toString().split(',');
                         position[0] = pos[0].toFloat();
                         position[1] = pos[1].toFloat();
-                    }
-
-                    if (attr.name().toString() == QString("Color"))
+                    } else if (attr.name() == "color")
                         color = QColor(attr.value().toString());
                 }
+
                 TileTemplate *tileTemplate = new TileTemplate(color, name, height, thickness, position, templateSet);
                 templateSet->addTileTemplate(tileTemplate, true);
             }
@@ -186,38 +164,29 @@ SavableTileTemplateSet *XMLTool::openTileTemplateSet(QString templateSetPath){
     return templateSet;
 }
 
-int XMLTool::saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *> &tileTemplateSets) {
-    QVector<SavableTileTemplateSet *> usedTileTemplateSets;
+int XMLTool::saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *> &tileTemplateSets)
+{
     QString tileMapPath = tileMap->savePath();
     QFile file(tileMapPath);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
-        return -1;
-    QTextStream out(&file);
+        return OpenFileError;
+
     QDomDocument doc;
-    QDomElement element;
-    QDomAttr attr;
     QDomProcessingInstruction instruction = doc.createProcessingInstruction( "xml", "version = \'1.0\' encoding=\'UTF-8\'" );
     doc.appendChild(instruction);
 
     QDomElement root = doc.createElement( "TileMap" );
-    attr = doc.createAttribute("width");
-    attr.setValue(QString::number(tileMap->mapSize().width()));
-    root.setAttributeNode(attr);
-    attr = doc.createAttribute("height");
-    attr.setValue(QString::number(tileMap->mapSize().height()));
-    root.setAttributeNode(attr);
-    doc.appendChild(root);
+    root.setAttribute("width", tileMap->mapSize().width());
+    root.setAttribute("height", tileMap->mapSize().height());
 
+    QVector<SavableTileTemplateSet *> usedTileTemplateSets;
     for (SavableTileTemplateSet *tts : tileTemplateSets) {
         if (tileMap->tileTemplateSetUsed(tts)) {
             usedTileTemplateSets.append(tts);
 
-            element = doc.createElement("TileTemplateSet");
-            element.setAttributeNode(attr);
-            attr = doc.createAttribute("SavePath");
-            attr.setValue(tts->savePath());
-            element.setAttributeNode(attr);
-            root.appendChild(element);
+            QDomElement templateSet = doc.createElement("TileTemplateSet");
+            templateSet.setAttribute("savePath", tts->savePath());
+            root.appendChild(templateSet);
         }
     }
 
@@ -226,89 +195,78 @@ int XMLTool::saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *>
             const Tile &tile = tileMap->cTileAt(x, y);
 
             if(tile.hasTileTemplate()) {
-                element = doc.createElement("Tile");
-                attr = doc.createAttribute("x");
-                attr.setValue(QString::number(x));
-                element.setAttributeNode(attr);
-                attr = doc.createAttribute("y");
-                attr.setValue(QString::number(y));
-                element.setAttributeNode(attr);
-                attr = doc.createAttribute("RelativeThickness");
-                attr.setValue(QString::number(tile.relativeThickness()));
-                element.setAttributeNode(attr);
-                attr = doc.createAttribute("RelativeHeight");
-                attr.setValue(QString::number(tile.relativeHeight()));
-                element.setAttributeNode(attr);
-                attr = doc.createAttribute("RelativePosition");
-                attr.setValue(QString("%1,%2").arg(
-                    QString::number(tile.relativePosition()[0]),
-                    QString::number(tile.relativePosition()[1])));
-                element.setAttributeNode(attr);
-                attr = doc.createAttribute("TemplateID");
-                int id=-1; int count=0;
-                for (SavableTileTemplateSet *set: usedTileTemplateSets) {
-                    if ((id=set->cTileTemplates().indexOf(tile.tileTemplate())) == -1) {
-                        count+=set->cTileTemplates().size();
-                        continue;
-                    } else {
-                        id += count;
+                QDomElement tileE = doc.createElement("Tile");
+
+                tileE.setAttribute("x", x);
+                tileE.setAttribute("y", y);
+                tileE.setAttribute("relativeThickness", tile.relativeThickness());
+                tileE.setAttribute("relativeHeight", tile.relativeHeight());
+                tileE.setAttribute("relativePosition", QString("%1,%2").arg(
+                                       QString::number(tile.relativePosition()[0]),
+                                       QString::number(tile.relativePosition()[1])));
+
+                int setId = -1, templateId;
+                for (int i = 0; i < usedTileTemplateSets.size(); ++i) {
+                    int j = usedTileTemplateSets[i]->cTileTemplates().indexOf(tile.tileTemplate());
+                    if (j != -1) {
+                        setId = i;
+                        templateId = j;
                         break;
                     }
                 }
-                if (id==-1) {
-                    qDebug() << "Dependent tileTemplateSet not found when saving tilemap.";
-                    return -1;
-                }
 
-                attr.setValue(QString::number(id));
-                element.setAttributeNode(attr);
-                root.appendChild(element);
+                //There should be no case where a tile is assigned to a template that is not contained in any active set.
+                // TODO : This currently does not consider default templates
+                Q_ASSERT(setId != -1);
+
+                tileE.setAttribute("templateSetId", setId);
+                tileE.setAttribute("templateId", templateId);
+
+                root.appendChild(tileE);
             }
         }
     }
+
+    doc.appendChild(root);
+
+    QTextStream out(&file);
     doc.save(out, 4);
     file.close();
-    return 0;
+    return NoError;
 }
 
-int XMLTool::saveTileTemplateSet(SavableTileTemplateSet *templateSet){
-    const QList<TileTemplate *> templatelist = templateSet->cTileTemplates();
-    QString templateSetPath = templateSet->savePath();
-    QFile file(templateSetPath);
+int XMLTool::saveTileTemplateSet(SavableTileTemplateSet *templateSet)
+{
+    QFile file(templateSet->savePath());
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate))
-        return -1;
-    QTextStream out(&file);
+        return OpenFileError;
+
     QDomDocument doc;
-    QDomElement element;
-    QDomAttr attr;
     QDomProcessingInstruction instruction = doc.createProcessingInstruction( "xml", "version = \'1.0\' encoding=\'UTF-8\'" );
     doc.appendChild(instruction);
 
     QDomElement root = doc.createElement( "TileTemplateSet" );
-    attr = doc.createAttribute("Name");
-    attr.setValue(templateSet->name());
-    root.setAttributeNode(attr);
-    doc.appendChild(root);
-    for(TileTemplate *temp: templatelist){
-        element = doc.createElement("TileTemplate");
-        attr = doc.createAttribute("Name");
-        attr.setValue(temp->name());
-        element.setAttributeNode(attr);
-        attr = doc.createAttribute("Height");
-        attr.setValue(QString::number(temp->height()));
-        element.setAttributeNode(attr);
-        attr = doc.createAttribute("Thickness");
-        attr.setValue(QString::number(temp->thickness()));
-        element.setAttributeNode(attr);
-        attr = doc.createAttribute("Position");
-        attr.setValue(QString("%1,%2").arg(QString::number(temp->position()[0]), QString::number(temp->position()[1])));
-        element.setAttributeNode(attr);
-        attr = doc.createAttribute("Color");
-        attr.setValue(temp->color().name());
-        element.setAttributeNode(attr);
-        root.appendChild(element);
+    root.setAttribute("name", templateSet->name());
+
+    const QList<TileTemplate *> templateList = templateSet->cTileTemplates();
+    for (TileTemplate *t: templateList) {
+        QDomElement templateE = doc.createElement("TileTemplate");
+
+        templateE.setAttribute("name", t->name());
+        templateE.setAttribute("height", t->height());
+        templateE.setAttribute("thickness", t->thickness());
+        templateE.setAttribute("position", QString("%1,%2").arg(
+                               QString::number(t->position()[0]),
+                               QString::number(t->position()[1])));
+        templateE.setAttribute("color", t->color().name());
+
+        root.appendChild(templateE);
     }
+
+    doc.appendChild(root);
+
+    QTextStream out(&file);
     doc.save(out, 4);
     file.close();
-    return 0;
+    return NoError;
 }

--- a/WallsAndHoles/xmltool.h
+++ b/WallsAndHoles/xmltool.h
@@ -2,7 +2,7 @@
 #define XMLTOOL_H
 
 #include "tilemap.h"
-#include "tiletemplateset.h"
+#include "savabletiletemplateset.h"
 
 #include <QDomDocument>
 #include <QFile>
@@ -14,10 +14,10 @@ class TileTemplateSetsView;
 namespace XMLTool {
 
     TileMap *openTileMap(QString tileMapPath, TileTemplateSetsView *tileTemplateSetView);
-    SharedTileTemplateSet openTileTemplateSet(QString templateSetPath);
+    SavableTileTemplateSet *openTileTemplateSet(QString templateSetPath);
 
-    int saveTileMap(TileMap *tileMap, const QList<SharedTileTemplateSet> &tileTemplateSets);
-    int saveTileTemplateSet(TileTemplateSet *templateSet);
+    int saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *> &tileTemplateSets);
+    int saveTileTemplateSet(SavableTileTemplateSet *templateSet);
 }
 
 #endif // XMLTOOL_H

--- a/WallsAndHoles/xmltool.h
+++ b/WallsAndHoles/xmltool.h
@@ -9,15 +9,21 @@
 #include <QTextStream>
 #include <QXmlStreamReader>
 
-class TileTemplateSetsView;
+class TileTemplateSetsManager;
 
 namespace XMLTool {
 
-    TileMap *openTileMap(QString tileMapPath, TileTemplateSetsView *tileTemplateSetView);
-    SavableTileTemplateSet *openTileTemplateSet(QString templateSetPath);
+enum SaveErrors {
+    NoError,
+    OpenFileError
+};
 
-    int saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *> &tileTemplateSets);
-    int saveTileTemplateSet(SavableTileTemplateSet *templateSet);
+TileMap *openTileMap(QString tileMapPath, TileTemplateSetsManager *tileTemplateSetManager);
+SavableTileTemplateSet *openTileTemplateSet(QString templateSetPath);
+
+int saveTileMap(TileMap *tileMap, const QList<SavableTileTemplateSet *> &tileTemplateSets);
+int saveTileTemplateSet(SavableTileTemplateSet *templateSet);
+
 }
 
 #endif // XMLTOOL_H

--- a/WallsAndHoles/xmltool.h
+++ b/WallsAndHoles/xmltool.h
@@ -1,18 +1,22 @@
 #ifndef XMLTOOL_H
 #define XMLTOOL_H
+
 #include "tilemap.h"
 #include "tiletemplateset.h"
+
 #include <QDomDocument>
 #include <QFile>
 #include <QTextStream>
 #include <QXmlStreamReader>
 
+class TileTemplateSetsView;
+
 namespace XMLTool {
 
-    SharedTileMap openTileMap(QString tileMapPath);
+    TileMap *openTileMap(QString tileMapPath, TileTemplateSetsView *tileTemplateSetView);
     SharedTileTemplateSet openTileTemplateSet(QString templateSetPath);
 
-    int saveTileMap(SharedTileMap tileMap, bool saveTemplates = true);
+    int saveTileMap(TileMap *tileMap, const QList<SharedTileTemplateSet> &tileTemplateSets);
     int saveTileTemplateSet(TileTemplateSet *templateSet);
 }
 


### PR DESCRIPTION
And some changes to the TileTemplate pipeline.

The highlights:

- Saving and loading was changed to be a bit cleaner, and handle more error situations. There is still a lot to do in regards to error handling with saving and loading, as there are ways to crash the program if you behave incorrectly. But, if you act well within the lines, all should work correctly.
- The file aspect of a TileTemplateSet has been moved to a sub class: SavableTileTemplateSet
- The actual set of TileTemplateSets has been moved to a new class: TileTemplateSetsManager. This now handles a lot of dialog around tileTemplateSet
- Removed SharedTileTemplate and SharedTileTemplateSet, as not much was gained from using them.

Notable things which still need fixing:
- A lot of the QActions for saving/removing need to be disabled in certain situations. Currently the handling isn't very clean, and in some cases crashes.
- As stated above, loading has a lot of error potential which needs to be handled.